### PR TITLE
Refactor Walk to take a path callback.

### DIFF
--- a/cmd/walk.go
+++ b/cmd/walk.go
@@ -150,7 +150,7 @@ func walkDirAndScheduleStats(desiredDir, outputDir string, inodes int, depGroup,
 		die("failed to create walk output files: %s", err)
 	}
 
-	walker := walk.New(files.WritePaths())
+	walker := walk.New(files.WritePaths(), true)
 
 	defer func() {
 		err = files.Close()

--- a/cmd/walk.go
+++ b/cmd/walk.go
@@ -145,13 +145,15 @@ func walkDirAndScheduleStats(desiredDir, outputDir string, inodes int, depGroup,
 	yamlPath string, s *scheduler.Scheduler) {
 	n := calculateSplitBasedOnInodes(inodes, desiredDir)
 
-	walker, err := walk.New(outputDir, n)
+	files, err := walk.NewFiles(outputDir, n)
 	if err != nil {
 		die("failed to create walk output files: %s", err)
 	}
 
+	walker := walk.New(files.WritePaths())
+
 	defer func() {
-		err = walker.Close()
+		err = files.Close()
 		if err != nil {
 			warn("failed to close walk output file: %s", err)
 		}
@@ -164,7 +166,7 @@ func walkDirAndScheduleStats(desiredDir, outputDir string, inodes int, depGroup,
 		die("failed to walk the filesystem: %s", err)
 	}
 
-	scheduleStatJobs(walker.OutputPaths(), depGroup, repGroup, yamlPath, s)
+	scheduleStatJobs(files.Paths, depGroup, repGroup, yamlPath, s)
 }
 
 // calculateSplitBasedOnInodes sees how many used inodes are on the given path

--- a/walk/file.go
+++ b/walk/file.go
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package walk
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const userOnlyPerm = 0700
+
+// WriteError is an error received when trying to write strings to disk.
+type WriteError struct {
+	Err error
+}
+
+func (e *WriteError) Error() string { return e.Err.Error() }
+
+func (e *WriteError) Unwrap() error { return e.Err }
+
+// Files represents a collection of output files that can be written to in a
+// round-robin.
+type Files struct {
+	files    []*os.File
+	Paths    []string
+	filesI   int
+	filesMax int
+	mu       sync.RWMutex
+	mus      []sync.Mutex
+}
+
+// NewFiles returns a Files that has a WritePaths method that will return a
+// PathsCallback function suitable for passing to New().
+//
+// This creates n output files in outDir, and writes the walk paths to those
+// files 1 per line in a round-robin.
+//
+// The output file paths can be found in the Paths property.
+//
+// Be sure to Close() after you've finished walking.
+func NewFiles(outDir string, n int) (*Files, error) {
+	if err := os.MkdirAll(outDir, userOnlyPerm); err != nil {
+		return nil, err
+	}
+
+	files := make([]*os.File, n)
+	outPaths := make([]string, n)
+
+	for i := range files {
+		var err error
+
+		path := filepath.Join(outDir, fmt.Sprintf("walk.%d", i+1))
+
+		files[i], err = os.Create(path)
+		if err != nil {
+			return nil, err
+		}
+
+		outPaths[i] = path
+	}
+
+	return &Files{
+		files:    files,
+		Paths:    outPaths,
+		filesMax: len(files),
+		mus:      make([]sync.Mutex, len(files)),
+	}, nil
+}
+
+// WritePaths returns a PathCallback function suitable for passing to New().
+//
+// Paths are written 1 per line to our output files in a round-robin.
+//
+// It will terminate the walk if writes to our output files fail.
+func (f *Files) WritePaths() PathCallback {
+	return func(path string) error {
+		return f.writePath(path)
+	}
+}
+
+// writePath is a thread-safe way of writing the given path to our next output
+// file. Returns a WriteError on failure to write to an output file.
+func (f *Files) writePath(path string) error {
+	f.mu.Lock()
+	i := f.filesI
+	f.filesI++
+
+	if f.filesI == f.filesMax {
+		f.filesI = 0
+	}
+
+	f.mu.Unlock()
+
+	f.mus[i].Lock()
+	defer f.mus[i].Unlock()
+
+	_, err := io.WriteString(f.files[i], path+"\n")
+	if err != nil {
+		err = &WriteError{Err: err}
+	}
+
+	return err
+}
+
+// Close should be called after Walk()ing to close all the output files.
+func (f *Files) Close() error {
+	for _, file := range f.files {
+		if err := file.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -30,7 +30,6 @@
 package walk
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -38,93 +37,44 @@ import (
 	"github.com/karrick/godirwalk"
 )
 
-const userOnlyPerm = 0700
 const walkers = 16
 const dirsChSize = 1024
 
-// WriteError is an error received when trying to write discovered paths to
-// disk.
-type WriteError struct {
-	Err error
-}
-
-func (e *WriteError) Error() string { return e.Err.Error() }
-
-func (e *WriteError) Unwrap() error { return e.Err }
+// PathCallback is a callback used by Walker.Walk() that receives a discovered
+// file path each time it's called. It should only return an error if you can no
+// longer cope with receiving more paths, and wish to terminate the Walk.
+type PathCallback func(path string) error
 
 // Walker can be used to quickly walk a filesystem to just see what paths there
 // are on it.
 type Walker struct {
-	outDir   string
-	files    []*os.File
-	filesI   int
-	filesMax int
-	mu       sync.RWMutex
-	mus      []sync.Mutex
-	dirsCh   chan string
-	active   sync.WaitGroup
-	err      error
-	errCB    ErrorCallback
-	ended    bool
+	cb     PathCallback
+	dirsCh chan string
+	active sync.WaitGroup
+	err    error
+	errCB  ErrorCallback
+	mu     sync.RWMutex
+	ended  bool
 }
 
-// New creates a new Walker that can Walk() a filesystem and write all the
-// encountered paths to the given number of output files in the given output
-// directory. The output files are created and opened ready for a Walk(). Any
-// error during that process is also returned.
-func New(outDir string, numOutputFiles int) (*Walker, error) {
-	w := &Walker{
-		outDir: outDir,
-	}
-
-	err := w.createOutputFiles(numOutputFiles)
-
-	return w, err
-}
-
-// createOutputFiles creates the given number of output files ready for writing
-// to.
-func (w *Walker) createOutputFiles(n int) error {
-	if err := os.MkdirAll(w.outDir, userOnlyPerm); err != nil {
-		return err
-	}
-
-	files := make([]*os.File, n)
-
-	for i := range files {
-		var err error
-
-		files[i], err = w.createOutputFile(i + 1)
-		if err != nil {
-			return err
-		}
-	}
-
-	w.files = files
-	w.filesMax = len(files)
-	w.mus = make([]sync.Mutex, len(files))
-
-	return nil
-}
-
-// createOutputFile creates an output file ready for writing to.
-func (w *Walker) createOutputFile(i int) (*os.File, error) {
-	return os.Create(filepath.Join(w.outDir, fmt.Sprintf("walk.%d", i)))
+// New creates a new Walker that can Walk() a filesystem and send all the
+// encountered paths to the given PathCallback.
+func New(cb PathCallback) *Walker {
+	return &Walker{cb: cb}
 }
 
 // ErrorCallback is a callback function you supply Walker.Walk(), and it
 // will be provided problematic paths encountered during the walk.
 type ErrorCallback func(path string, err error)
 
-// Walk will discover all the paths nested under the given dir, and output them
-// 1 per line to walk.* files in our outDir. Be sure to Close() after you've
-// finished walking.
+// Walk will discover all the paths nested under the given dir, and send them to
+// our PathCallback.
 //
-// The given callback will be called every time there's an error handling a file
-// during the walk. Errors writing to an output file will result in the walk
-// terminating early and this method returning the error; other kinds of errors
-// will mean the path isn't output, but the walk will continue and this method
-// won't return an error.
+// The given error callback will be called every time there's an error handling
+// a file during the walk. Errors writing to an output file will result in the
+// walk terminating early and this method returning the error; other kinds of
+// errors will mean the path isn't output, but the walk will continue and this
+// method won't return an error.
 func (w *Walker) Walk(dir string, cb ErrorCallback) error {
 	dir = filepath.Clean(dir)
 
@@ -186,15 +136,19 @@ func (w *Walker) processDir(dir string, buffer []byte) {
 		return
 	}
 
-	subDirs, otherEntries, ok := w.getImmediateChildren(dir, buffer)
+	subDirs, paths, ok := w.getImmediateChildren(dir, buffer)
 	if !ok {
 		return
 	}
 
-	if err := w.writeEntries(append(otherEntries, dir)); err != nil {
-		w.terminate(err)
+	paths = append(paths, dir)
+	for _, path := range paths {
+		if err := w.cb(path); err != nil {
+			w.errCB(path, err)
+			w.terminate(err)
 
-		return
+			return
+		}
 	}
 
 	for _, subDir := range subDirs {
@@ -237,43 +191,6 @@ func (w *Walker) getImmediateChildren(dir string, buffer []byte) ([]string, []st
 	return subDirs, otherEntries, true
 }
 
-// writeEntries writes the given paths to our output files.
-func (w *Walker) writeEntries(paths []string) error {
-	for _, path := range paths {
-		if err := w.writePath(path); err != nil {
-			w.errCB(path, err)
-
-			return err
-		}
-	}
-
-	return nil
-}
-
-// writePath is a thread-safe way of writing the given path to our next output
-// file. Returns a WriteError on failure to write to an output file.
-func (w *Walker) writePath(path string) error {
-	w.mu.Lock()
-	i := w.filesI
-	w.filesI++
-
-	if w.filesI == w.filesMax {
-		w.filesI = 0
-	}
-
-	w.mu.Unlock()
-
-	w.mus[i].Lock()
-	defer w.mus[i].Unlock()
-
-	_, err := w.files[i].WriteString(path + "\n")
-	if err != nil {
-		err = &WriteError{Err: err}
-	}
-
-	return err
-}
-
 // terminate will store the err on self on the first call to terminate, and
 // cause subsequent terminated() calls to return true.
 func (w *Walker) terminate(err error) {
@@ -283,26 +200,4 @@ func (w *Walker) terminate(err error) {
 	if w.err == nil {
 		w.err = err
 	}
-}
-
-// Close should be called after Walk()ing to close all the output files.
-func (w *Walker) Close() error {
-	for _, file := range w.files {
-		if err := file.Close(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// OutputPaths gives you the paths to the Walk() output files.
-func (w *Walker) OutputPaths() []string {
-	outPaths := make([]string, len(w.files))
-
-	for i, file := range w.files {
-		outPaths[i] = file.Name()
-	}
-
-	return outPaths
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -58,7 +58,7 @@ func TestWalk(t *testing.T) {
 			files, err := NewFiles(outDir, 1)
 			So(err, ShouldBeNil)
 
-			w := New(files.WritePaths())
+			w := New(files.WritePaths(), true)
 
 			err = w.Walk(walkDir, cb)
 			So(err, ShouldBeNil)
@@ -79,7 +79,7 @@ func TestWalk(t *testing.T) {
 			n := 4
 			files, err := NewFiles(outDir, n)
 			So(err, ShouldBeNil)
-			w := New(files.WritePaths())
+			w := New(files.WritePaths(), true)
 
 			err = w.Walk(walkDir, cb)
 			So(err, ShouldBeNil)
@@ -121,7 +121,7 @@ func TestWalk(t *testing.T) {
 		Convey("Write errors during a walk are reported and the walk terminated", func() {
 			files, err := NewFiles(outDir, 1)
 			So(err, ShouldBeNil)
-			w := New(files.WritePaths())
+			w := New(files.WritePaths(), true)
 
 			err = files.files[0].Close()
 			So(err, ShouldBeNil)
@@ -146,7 +146,7 @@ func TestWalk(t *testing.T) {
 		Convey("Read errors during a walk are reported and the path skipped", func() {
 			files, err := NewFiles(outDir, 1)
 			So(err, ShouldBeNil)
-			w := New(files.WritePaths())
+			w := New(files.WritePaths(), true)
 
 			err = w.Walk("/root", cb)
 			So(err, ShouldBeNil)

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -55,13 +55,16 @@ func TestWalk(t *testing.T) {
 		}
 
 		Convey("You can output the paths to a file", func() {
-			w, err := New(outDir, 1)
+			files, err := NewFiles(outDir, 1)
 			So(err, ShouldBeNil)
+
+			w := New(files.WritePaths())
 
 			err = w.Walk(walkDir, cb)
 			So(err, ShouldBeNil)
 
 			outPath := filepath.Join(outDir, "walk.1")
+			So(files.Paths[0], ShouldEqual, outPath)
 			content, err := os.ReadFile(outPath)
 			So(err, ShouldBeNil)
 
@@ -74,15 +77,14 @@ func TestWalk(t *testing.T) {
 
 		Convey("You can output the paths to multiple files", func() {
 			n := 4
-			w, err := New(outDir, n)
+			files, err := NewFiles(outDir, n)
 			So(err, ShouldBeNil)
+			w := New(files.WritePaths())
 
 			err = w.Walk(walkDir, cb)
 			So(err, ShouldBeNil)
 
 			totalFound := 0
-
-			outPaths := w.OutputPaths()
 
 			for i := 1; i <= n+1; i++ {
 				outPath := filepath.Join(outDir, fmt.Sprintf("walk.%d", i))
@@ -91,7 +93,7 @@ func TestWalk(t *testing.T) {
 				if i <= n {
 					So(errr, ShouldBeNil)
 
-					So(outPaths[i-1], ShouldEqual, outPath)
+					So(files.Paths[i-1], ShouldEqual, outPath)
 
 					found, dups, _ := checkPaths(string(content), expectedPaths)
 
@@ -106,21 +108,22 @@ func TestWalk(t *testing.T) {
 			So(totalFound, ShouldEqual, 81)
 			So(len(walkErrors), ShouldEqual, 0)
 
-			err = w.Close()
+			err = files.Close()
 			So(err, ShouldBeNil)
 
-			err = w.files[0].Close()
+			err = files.files[0].Close()
 			So(err, ShouldNotBeNil)
 
-			err = w.Close()
+			err = files.Close()
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Write errors during a walk are reported and the walk terminated", func() {
-			w, err := New(outDir, 1)
+			files, err := NewFiles(outDir, 1)
 			So(err, ShouldBeNil)
+			w := New(files.WritePaths())
 
-			err = w.files[0].Close()
+			err = files.files[0].Close()
 			So(err, ShouldBeNil)
 
 			err = w.Walk(walkDir, cb)
@@ -141,8 +144,9 @@ func TestWalk(t *testing.T) {
 		})
 
 		Convey("Read errors during a walk are reported and the path skipped", func() {
-			w, err := New(outDir, 1)
+			files, err := NewFiles(outDir, 1)
 			So(err, ShouldBeNil)
+			w := New(files.WritePaths())
 
 			err = w.Walk("/root", cb)
 			So(err, ShouldBeNil)
@@ -156,8 +160,8 @@ func TestWalk(t *testing.T) {
 		})
 	})
 
-	Convey("You can't make a Walker on a bad directory", t, func() {
-		_, err := New("/foo", 1)
+	Convey("You can't create output files in a bad directory", t, func() {
+		_, err := NewFiles("/foo", 1)
 		So(err, ShouldNotBeNil)
 
 		tmpDir := t.TempDir()
@@ -165,7 +169,7 @@ func TestWalk(t *testing.T) {
 		err = os.Mkdir(outDir, permNoWrite)
 		So(err, ShouldBeNil)
 
-		_, err = New(outDir, 1)
+		_, err = NewFiles(outDir, 1)
 		So(err, ShouldNotBeNil)
 	})
 }


### PR DESCRIPTION
This is to allow external software to use the fast Walking feature without having to store the results in files.