### PR TITLE
Add dates that quota will be full to group usage.

### DIFF
--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -790,6 +790,11 @@ func TestOwners(t *testing.T) {
 func fixUsageTimes(mt []*Usage) {
 	for _, u := range mt {
 		u.Mtime = fixtimes.FixTime(u.Mtime)
+
+		if !u.DateNoSpace.IsZero() {
+			u.DateNoSpace = fixtimes.FixTime(u.DateNoSpace)
+			u.DateNoFiles = fixtimes.FixTime(u.DateNoFiles)
+		}
 	}
 }
 

--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -243,7 +243,8 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 							UsageSize: halfGig + twoGig, QuotaSize: 4000000000, UsageInodes: 2,
 							QuotaInodes: 20, Mtime: expectedMtimeA},
 						{Name: groupName, GID: uint32(gid), UIDs: []uint32{uint32(uid)}, BaseDir: projectD,
-							UsageSize: 15, QuotaSize: 0, UsageInodes: 5, QuotaInodes: 0, Mtime: expectedMtime},
+							UsageSize: 15, QuotaSize: 0, UsageInodes: 5, QuotaInodes: 0, Mtime: expectedMtime,
+							DateNoSpace: yesterday, DateNoFiles: yesterday},
 						{Name: "group2", GID: 2, UIDs: []uint32{88888}, Owner: "Barbara", BaseDir: projectC1,
 							UsageSize: 40, QuotaSize: 400, UsageInodes: 1, QuotaInodes: 40, Mtime: expectedMtime},
 						{Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB123,
@@ -365,6 +366,17 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 						mainTable, err := bdr.GroupUsage()
 						fixUsageTimes(mainTable)
 
+						dateNoSpace := today.Add(4 * 24 * time.Hour)
+						So(mainTable[0].DateNoSpace, ShouldHappenOnOrBetween,
+							dateNoSpace.Add(-2*time.Second), dateNoSpace.Add(2*time.Second))
+
+						dateNoTime := today.Add(18 * 24 * time.Hour)
+						So(mainTable[0].DateNoFiles, ShouldHappenOnOrBetween,
+							dateNoTime.Add(-2*time.Second), dateNoTime.Add(2*time.Second))
+
+						mainTable[0].DateNoSpace = time.Time{}
+						mainTable[0].DateNoFiles = time.Time{}
+
 						So(err, ShouldBeNil)
 						So(len(mainTable), ShouldEqual, 6)
 						So(mainTable, ShouldResemble, []*Usage{
@@ -372,7 +384,8 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 								UsageSize: twoGig + halfGig*2, QuotaSize: fiveGig,
 								UsageInodes: 3, QuotaInodes: 21, Mtime: expectedMtimeA},
 							{Name: groupName, GID: uint32(gid), UIDs: []uint32{uint32(uid)}, BaseDir: projectD,
-								UsageSize: 10, QuotaSize: 0, UsageInodes: 4, QuotaInodes: 0, Mtime: expectedMtime},
+								UsageSize: 10, QuotaSize: 0, UsageInodes: 4, QuotaInodes: 0, Mtime: expectedMtime,
+								DateNoSpace: today, DateNoFiles: today},
 							{Name: "group2", GID: 2, UIDs: []uint32{88888}, Owner: "Barbara", BaseDir: projectC1,
 								UsageSize: 40, QuotaSize: 400, UsageInodes: 1,
 								QuotaInodes: 40, Mtime: expectedMtime},

--- a/cmd/basedir.go
+++ b/cmd/basedir.go
@@ -33,7 +33,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -56,8 +55,6 @@ const (
 // options for this cmd.
 var quotaPath string
 var ownersPath string
-var basedirMDTRegexp = regexp.MustCompile(`\/mdt\d(\/|\z)`)
-var basedirHumgenRegexp = regexp.MustCompile(`\/lustre\/scratch\d\d\d\/(humgen|hgi|tol|pam|opentargets)`)
 
 // basedirCmd represents the basedir command.
 var basedirCmd = &cobra.Command{

--- a/combine/combine.go
+++ b/combine/combine.go
@@ -117,11 +117,7 @@ func Merge(inputs []*os.File, output io.Writer, streamFunc Merger) error {
 		return err
 	}
 
-	if err = cleanup(); err != nil {
-		return err
-	}
-
-	return nil
+	return cleanup()
 }
 
 // MergeAndCompress takes a list of open files, an open output file, and a

--- a/internal/fixtimes/fix.go
+++ b/internal/fixtimes/fix.go
@@ -31,6 +31,8 @@ import (
 	"time"
 )
 
+// FixTime alters the given time's zone to be a fixed one, for consistent
+// testing purposes.
 func FixTime(t time.Time) time.Time {
 	_, offset := time.Now().Zone()
 	l := time.FixedZone("", offset)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -53,9 +53,6 @@ import (
 	ifs "github.com/wtsi-ssg/wrstat/v4/internal/fs"
 )
 
-const dirPerms = 0755
-const exampleDgutDirParentSuffix = "dgut.dbs"
-
 func TestIDsToWanted(t *testing.T) {
 	Convey("restrictGIDs returns bad query if you don't want any of the given ids", t, func() {
 		_, err := restrictGIDs(map[uint32]bool{1: true}, []uint32{2})

--- a/stat/paths_test.go
+++ b/stat/paths_test.go
@@ -267,7 +267,7 @@ type statterWithConcurrentTest struct {
 	i  int
 }
 
-func (s *statterWithConcurrentTest) Lstat(path string) (info fs.FileInfo, err error) {
+func (s *statterWithConcurrentTest) Lstat(_ string) (info fs.FileInfo, err error) {
 	s.i++
 	if s.i == 1 {
 		return

--- a/summary/groupuser.go
+++ b/summary/groupuser.go
@@ -143,7 +143,7 @@ func NewByGroupUser() *GroupUser {
 // Add is a github.com/wtsi-ssg/wrstat/stat Operation. It will add the file size
 // and increment the file count summed for the info's group and user. If path is
 // a directory, it is ignored.
-func (g *GroupUser) Add(path string, info fs.FileInfo) error {
+func (g *GroupUser) Add(_ string, info fs.FileInfo) error {
 	if info.IsDir() {
 		return nil
 	}


### PR DESCRIPTION
Adds DateNoSpace and DateNoFiles to Usage when getting GroupUsage. Front-end will then need to do something like basedirs/reader.go usageStatus() given those dates to calculate quota status based on 3 days from now.