### PR TITLE
Fix for mtime comparison filter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.so
 *.dylib
 ./wrstat
-wrstat
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 ./wrstat
+wrstat
 
 # Test binary, built with `go test -c`
 *.test

--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -225,15 +225,19 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 
 				bdr.mountPoints = bd.mountPoints
 
-				groupCache := GroupCache{
-					1: "group1",
-					2: "group2",
+				groupCache := &GroupCache{
+					data: map[uint32]string{
+						1: "group1",
+						2: "group2",
+					},
 				}
 				bdr.groupCache = groupCache
 
-				bdr.userCache = UserCache{
-					101: "user101",
-					102: "user102",
+				bdr.userCache = &UserCache{
+					data: map[uint32]string{
+						101: "user101",
+						102: "user102",
+					},
 				}
 
 				expectedMtime := fixtimes.FixTime(time.Unix(50, 0))
@@ -246,38 +250,62 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 					So(err, ShouldBeNil)
 					So(len(mainTable), ShouldEqual, 6)
 					So(mainTable, ShouldResemble, []*Usage{
-						{Name: "group1", GID: 1, UIDs: []uint32{101}, Owner: "Alan", BaseDir: projectA,
+						{
+							Name: "group1", GID: 1, UIDs: []uint32{101}, Owner: "Alan", BaseDir: projectA,
 							UsageSize: halfGig + twoGig, QuotaSize: 4000000000, UsageInodes: 2,
-							QuotaInodes: 20, Mtime: expectedMtimeA},
-						{Name: groupName, GID: uint32(gid), UIDs: []uint32{uint32(uid)}, BaseDir: projectD,
+							QuotaInodes: 20, Mtime: expectedMtimeA,
+						},
+						{
+							Name: groupName, GID: uint32(gid), UIDs: []uint32{uint32(uid)}, BaseDir: projectD,
 							UsageSize: 15, QuotaSize: 0, UsageInodes: 5, QuotaInodes: 0, Mtime: expectedMtime,
-							DateNoSpace: yesterday, DateNoFiles: yesterday},
-						{Name: "group2", GID: 2, UIDs: []uint32{88888}, Owner: "Barbara", BaseDir: projectC1,
-							UsageSize: 40, QuotaSize: 400, UsageInodes: 1, QuotaInodes: 40, Mtime: expectedMtime},
-						{Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB123,
-							UsageSize: 30, QuotaSize: 400, UsageInodes: 1, QuotaInodes: 40, Mtime: expectedMtime},
-						{Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB125,
-							UsageSize: 20, QuotaSize: 300, UsageInodes: 1, QuotaInodes: 30, Mtime: expectedMtime},
-						{Name: "77777", GID: 77777, UIDs: []uint32{102}, Owner: "", BaseDir: user2, UsageSize: 60,
-							QuotaSize: 500, UsageInodes: 1, QuotaInodes: 50, Mtime: expectedMtime},
+							DateNoSpace: yesterday, DateNoFiles: yesterday,
+						},
+						{
+							Name: "group2", GID: 2, UIDs: []uint32{88888}, Owner: "Barbara", BaseDir: projectC1,
+							UsageSize: 40, QuotaSize: 400, UsageInodes: 1, QuotaInodes: 40, Mtime: expectedMtime,
+						},
+						{
+							Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB123,
+							UsageSize: 30, QuotaSize: 400, UsageInodes: 1, QuotaInodes: 40, Mtime: expectedMtime,
+						},
+						{
+							Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB125,
+							UsageSize: 20, QuotaSize: 300, UsageInodes: 1, QuotaInodes: 30, Mtime: expectedMtime,
+						},
+						{
+							Name: "77777", GID: 77777, UIDs: []uint32{102}, Owner: "", BaseDir: user2, UsageSize: 60,
+							QuotaSize: 500, UsageInodes: 1, QuotaInodes: 50, Mtime: expectedMtime,
+						},
 					})
 
 					mainTable, err = bdr.UserUsage()
 					fixUsageTimes(mainTable)
 
 					expectedMainTable := []*Usage{
-						{Name: "user101", UID: 101, GIDs: []uint32{1}, BaseDir: projectA,
-							UsageSize: halfGig + twoGig, UsageInodes: 2, Mtime: expectedMtimeA},
-						{Name: "user102", UID: 102, GIDs: []uint32{2}, BaseDir: projectB123, UsageSize: 30,
-							UsageInodes: 1, Mtime: expectedMtime},
-						{Name: "user102", UID: 102, GIDs: []uint32{2}, BaseDir: projectB125, UsageSize: 20,
-							UsageInodes: 1, Mtime: expectedMtime},
-						{Name: "user102", UID: 102, GIDs: []uint32{77777}, BaseDir: user2, UsageSize: 60,
-							UsageInodes: 1, Mtime: expectedMtime},
-						{Name: "88888", UID: 88888, GIDs: []uint32{2}, BaseDir: projectC1, UsageSize: 40,
-							UsageInodes: 1, Mtime: expectedMtime},
-						{Name: username, UID: uint32(uid), GIDs: []uint32{uint32(gid)}, BaseDir: projectD,
-							UsageSize: 15, UsageInodes: 5, Mtime: expectedMtime},
+						{
+							Name: "user101", UID: 101, GIDs: []uint32{1}, BaseDir: projectA,
+							UsageSize: halfGig + twoGig, UsageInodes: 2, Mtime: expectedMtimeA,
+						},
+						{
+							Name: "user102", UID: 102, GIDs: []uint32{2}, BaseDir: projectB123, UsageSize: 30,
+							UsageInodes: 1, Mtime: expectedMtime,
+						},
+						{
+							Name: "user102", UID: 102, GIDs: []uint32{2}, BaseDir: projectB125, UsageSize: 20,
+							UsageInodes: 1, Mtime: expectedMtime,
+						},
+						{
+							Name: "user102", UID: 102, GIDs: []uint32{77777}, BaseDir: user2, UsageSize: 60,
+							UsageInodes: 1, Mtime: expectedMtime,
+						},
+						{
+							Name: "88888", UID: 88888, GIDs: []uint32{2}, BaseDir: projectC1, UsageSize: 40,
+							UsageInodes: 1, Mtime: expectedMtime,
+						},
+						{
+							Name: username, UID: uint32(uid), GIDs: []uint32{uint32(gid)}, BaseDir: projectD,
+							UsageSize: 15, UsageInodes: 5, Mtime: expectedMtime,
+						},
 					}
 
 					sort.Slice(expectedMainTable, func(i, j int) bool {
@@ -387,24 +415,36 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 						So(err, ShouldBeNil)
 						So(len(mainTable), ShouldEqual, 6)
 						So(mainTable, ShouldResemble, []*Usage{
-							{Name: "group1", GID: 1, UIDs: []uint32{101}, Owner: "Alan", BaseDir: projectA,
+							{
+								Name: "group1", GID: 1, UIDs: []uint32{101}, Owner: "Alan", BaseDir: projectA,
 								UsageSize: twoGig + halfGig*2, QuotaSize: fiveGig,
-								UsageInodes: 3, QuotaInodes: 21, Mtime: expectedMtimeA},
-							{Name: groupName, GID: uint32(gid), UIDs: []uint32{uint32(uid)}, BaseDir: projectD,
+								UsageInodes: 3, QuotaInodes: 21, Mtime: expectedMtimeA,
+							},
+							{
+								Name: groupName, GID: uint32(gid), UIDs: []uint32{uint32(uid)}, BaseDir: projectD,
 								UsageSize: 10, QuotaSize: 0, UsageInodes: 4, QuotaInodes: 0, Mtime: expectedMtime,
-								DateNoSpace: today, DateNoFiles: today},
-							{Name: "group2", GID: 2, UIDs: []uint32{88888}, Owner: "Barbara", BaseDir: projectC1,
+								DateNoSpace: today, DateNoFiles: today,
+							},
+							{
+								Name: "group2", GID: 2, UIDs: []uint32{88888}, Owner: "Barbara", BaseDir: projectC1,
 								UsageSize: 40, QuotaSize: 400, UsageInodes: 1,
-								QuotaInodes: 40, Mtime: expectedMtime},
-							{Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB123,
+								QuotaInodes: 40, Mtime: expectedMtime,
+							},
+							{
+								Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB123,
 								UsageSize: 30, QuotaSize: 400, UsageInodes: 1,
-								QuotaInodes: 40, Mtime: expectedMtime},
-							{Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB125,
+								QuotaInodes: 40, Mtime: expectedMtime,
+							},
+							{
+								Name: "group2", GID: 2, UIDs: []uint32{102}, Owner: "Barbara", BaseDir: projectB125,
 								UsageSize: 20, QuotaSize: 300, UsageInodes: 1,
-								QuotaInodes: 30, Mtime: expectedMtime},
-							{Name: "77777", GID: 77777, UIDs: []uint32{102}, Owner: "", BaseDir: user2,
+								QuotaInodes: 30, Mtime: expectedMtime,
+							},
+							{
+								Name: "77777", GID: 77777, UIDs: []uint32{102}, Owner: "", BaseDir: user2,
 								UsageSize: 60, QuotaSize: 500, UsageInodes: 1,
-								QuotaInodes: 50, Mtime: expectedMtime},
+								QuotaInodes: 50, Mtime: expectedMtime,
+							},
 						})
 
 						history, err := bdr.History(1, projectA)
@@ -638,9 +678,9 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 					wbo, err := bdr.UserUsageTable()
 					So(err, ShouldBeNil)
 
-					groupsToID := make(map[string]uint32, len(bdr.userCache))
+					groupsToID := make(map[string]uint32, len(bdr.userCache.data))
 
-					for uid, name := range bdr.userCache {
+					for uid, name := range bdr.userCache.data {
 						groupsToID[name] = uid
 					}
 

--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -33,6 +33,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -910,6 +911,48 @@ func TestOwners(t *testing.T) {
 			2: "Barbara",
 			4: "Dellilah",
 		})
+	})
+}
+
+func TestCaches(t *testing.T) {
+	Convey("Given a GroupCache, accessing it in multiple threads should be safe.", t, func() {
+		var wg sync.WaitGroup
+
+		g := NewGroupCache()
+
+		wg.Add(2)
+
+		go func() {
+			g.GroupName(0)
+			wg.Done()
+		}()
+
+		go func() {
+			g.GroupName(0)
+			wg.Done()
+		}()
+
+		wg.Wait()
+	})
+
+	Convey("Given a UserCache, accessing it in multiple threads should be safe.", t, func() {
+		var wg sync.WaitGroup
+
+		u := NewUserCache()
+
+		wg.Add(2)
+
+		go func() {
+			u.UserName(0)
+			wg.Done()
+		}()
+
+		go func() {
+			u.UserName(0)
+			wg.Done()
+		}()
+
+		wg.Wait()
 	})
 }
 

--- a/basedirs/cache.go
+++ b/basedirs/cache.go
@@ -30,12 +30,18 @@ package basedirs
 import (
 	"os/user"
 	"strconv"
+	"sync"
 )
+
+var gcmu, ucmu sync.RWMutex
 
 type GroupCache map[uint32]string
 
 func (g GroupCache) GroupName(gid uint32) string {
+	gcmu.RLock()
 	groupName, ok := g[gid]
+	gcmu.RUnlock()
+
 	if ok {
 		return groupName
 	}
@@ -47,7 +53,9 @@ func (g GroupCache) GroupName(gid uint32) string {
 		groupStr = group.Name
 	}
 
+	gcmu.Lock()
 	g[gid] = groupStr
+	gcmu.Unlock()
 
 	return groupStr
 }
@@ -55,7 +63,10 @@ func (g GroupCache) GroupName(gid uint32) string {
 type UserCache map[uint32]string
 
 func (u UserCache) UserName(uid uint32) string {
+	ucmu.RLock()
 	userName, ok := u[uid]
+	ucmu.RUnlock()
+
 	if ok {
 		return userName
 	}
@@ -67,7 +78,9 @@ func (u UserCache) UserName(uid uint32) string {
 		userStr = uu.Username
 	}
 
+	ucmu.Lock()
 	u[uid] = userStr
+	ucmu.Unlock()
 
 	return userStr
 }

--- a/basedirs/cache.go
+++ b/basedirs/cache.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 )
 
-var gcmu, ucmu sync.RWMutex
+var gcmu, ucmu sync.RWMutex //nolint:gochecknoglobals
 
 type GroupCache map[uint32]string
 

--- a/basedirs/cache.go
+++ b/basedirs/cache.go
@@ -33,14 +33,21 @@ import (
 	"sync"
 )
 
-var gcmu, ucmu sync.RWMutex //nolint:gochecknoglobals
+type GroupCache struct {
+	mu   sync.RWMutex
+	data map[uint32]string
+}
 
-type GroupCache map[uint32]string
+func NewGroupCache() *GroupCache {
+	return &GroupCache{
+		data: make(map[uint32]string),
+	}
+}
 
-func (g GroupCache) GroupName(gid uint32) string {
-	gcmu.RLock()
-	groupName, ok := g[gid]
-	gcmu.RUnlock()
+func (g *GroupCache) GroupName(gid uint32) string {
+	g.mu.RLock()
+	groupName, ok := g.data[gid]
+	g.mu.RUnlock()
 
 	if ok {
 		return groupName
@@ -53,19 +60,28 @@ func (g GroupCache) GroupName(gid uint32) string {
 		groupStr = group.Name
 	}
 
-	gcmu.Lock()
-	g[gid] = groupStr
-	gcmu.Unlock()
+	g.mu.Lock()
+	g.data[gid] = groupStr
+	g.mu.Unlock()
 
 	return groupStr
 }
 
-type UserCache map[uint32]string
+type UserCache struct {
+	mu   sync.RWMutex
+	data map[uint32]string
+}
 
-func (u UserCache) UserName(uid uint32) string {
-	ucmu.RLock()
-	userName, ok := u[uid]
-	ucmu.RUnlock()
+func NewUserCache() *UserCache {
+	return &UserCache{
+		data: make(map[uint32]string),
+	}
+}
+
+func (u *UserCache) UserName(uid uint32) string {
+	u.mu.RLock()
+	userName, ok := u.data[uid]
+	u.mu.RUnlock()
 
 	if ok {
 		return userName
@@ -78,9 +94,9 @@ func (u UserCache) UserName(uid uint32) string {
 		userStr = uu.Username
 	}
 
-	ucmu.Lock()
-	u[uid] = userStr
-	ucmu.Unlock()
+	u.mu.Lock()
+	u.data[uid] = userStr
+	u.mu.Unlock()
 
 	return userStr
 }

--- a/basedirs/reader.go
+++ b/basedirs/reader.go
@@ -36,18 +36,20 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-const secondsInDay = time.Hour * 24
-const threeDays = 3 * secondsInDay
-const quotaStatusOK = "OK"
-const quotaStatusNotOK = "Not OK"
+const (
+	secondsInDay     = time.Hour * 24
+	threeDays        = 3 * secondsInDay
+	quotaStatusOK    = "OK"
+	quotaStatusNotOK = "Not OK"
+)
 
 // BaseDirReader is used to read the information stored in a BaseDir database.
 type BaseDirReader struct {
 	db          *bolt.DB
 	ch          codec.Handle
 	mountPoints mountPoints
-	groupCache  GroupCache
-	userCache   UserCache
+	groupCache  *GroupCache
+	userCache   *UserCache
 	owners      map[uint32]string
 }
 
@@ -76,8 +78,8 @@ func NewReader(dbPath, ownersPath string) (*BaseDirReader, error) {
 		db:          db,
 		ch:          new(codec.BincHandle),
 		mountPoints: mp,
-		groupCache:  make(GroupCache),
-		userCache:   make(UserCache),
+		groupCache:  NewGroupCache(),
+		userCache:   NewUserCache(),
 		owners:      owners,
 	}, nil
 }

--- a/server/static/wrstat/src/format.ts
+++ b/server/static/wrstat/src/format.ts
@@ -65,7 +65,7 @@ export const formatNumber = (n: number) => numberFormatter.format(n),
 
 		return formatNumber(n) + " " + byteUnits[unit];
 	},
-	asDaysAgo = (date: string) => Math.max(0, Math.round((now - new Date(date).valueOf()) / msInDay)),
+	asDaysAgo = (date: string) => Math.max(0, Math.floor((now - new Date(date).valueOf()) / msInDay)),
 	asTimeAgo = (dateStr: string) => {
 		const duration = dateFns.intervalToDuration({
 			start: new Date(dateStr),


### PR DESCRIPTION
We think the reason why you can see data that isnt within the filtered mtime is due to a rounding error, so we're now rounding down using the floor method to fix this.