### PR TITLE
fix .gitignore to ignore file but not folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.so
 *.dylib
 ./wrstat
+wrstat
+!wrstat/
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
It wasn't gitignoring my wrstat binary for some reason, but if i added wrstat to the gitignore, which vscode wants to do, it'll also ignore the wrstat folder in server/static. This fixes it for me