### PR TITLE
Fix merging of results from two different runs.

### DIFF
--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -419,7 +419,8 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 						So(err, ShouldBeNil)
 
 						// Add new…
-						fs.Touch(treePath, time.Now())
+						err = fs.Touch(treePath, time.Now())
+						So(err, ShouldBeNil)
 
 						tree, err = dgut.NewTree(treePath)
 						So(err, ShouldBeNil)

--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -42,6 +42,7 @@ import (
 	internaldata "github.com/wtsi-ssg/wrstat/v4/internal/data"
 	internaldb "github.com/wtsi-ssg/wrstat/v4/internal/db"
 	"github.com/wtsi-ssg/wrstat/v4/internal/fixtimes"
+	"github.com/wtsi-ssg/wrstat/v4/internal/fs"
 	"github.com/wtsi-ssg/wrstat/v4/summary"
 	bolt "go.etcd.io/bbolt"
 )
@@ -73,7 +74,8 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 		files[0].SizeOfEachFile = halfGig
 		files[1].SizeOfEachFile = twoGig
 
-		tree, err := internaldb.CreateDGUTDBFromFakeFiles(t, files)
+		yesterday := fixtimes.FixTime(time.Now().Add(-24 * time.Hour))
+		tree, treePath, err := internaldb.CreateDGUTDBFromFakeFiles(t, files, yesterday)
 		So(err, ShouldBeNil)
 
 		projectA := locDirs[0]
@@ -88,6 +90,8 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 
 		dir := t.TempDir()
 		dbPath := filepath.Join(dir, "basedir.db")
+
+		dbModTime := fs.ModTime(treePath)
 
 		bd, err := NewCreator(dbPath, splits, minDirs, tree, quotas)
 		So(err, ShouldBeNil)
@@ -109,14 +113,15 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 				So(err, ShouldBeNil)
 				So(dcss, ShouldResemble, dgut.DCSs{
 					{
-						Dir:   projectA,
-						Count: 2,
-						Size:  halfGig + twoGig,
-						Atime: expectedAtime,
-						Mtime: expectedMtimeA,
-						GIDs:  []uint32{1},
-						UIDs:  []uint32{101},
-						FTs:   expectedFTsBam,
+						Dir:     projectA,
+						Count:   2,
+						Size:    halfGig + twoGig,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtimeA,
+						GIDs:    []uint32{1},
+						UIDs:    []uint32{101},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 				})
 
@@ -124,34 +129,37 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 				So(err, ShouldBeNil)
 				So(dcss, ShouldResemble, dgut.DCSs{
 					{
-						Dir:   projectC1,
-						Count: 1,
-						Size:  40,
-						Atime: expectedAtime,
-						Mtime: expectedMtime,
-						GIDs:  []uint32{2},
-						UIDs:  []uint32{88888},
-						FTs:   expectedFTsBam,
+						Dir:     projectC1,
+						Count:   1,
+						Size:    40,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtime,
+						GIDs:    []uint32{2},
+						UIDs:    []uint32{88888},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 					{
-						Dir:   projectB123,
-						Count: 1,
-						Size:  30,
-						Atime: expectedAtime,
-						Mtime: expectedMtime,
-						GIDs:  []uint32{2},
-						UIDs:  []uint32{102},
-						FTs:   expectedFTsBam,
+						Dir:     projectB123,
+						Count:   1,
+						Size:    30,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtime,
+						GIDs:    []uint32{2},
+						UIDs:    []uint32{102},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 					{
-						Dir:   projectB125,
-						Count: 1,
-						Size:  20,
-						Atime: expectedAtime,
-						Mtime: expectedMtime,
-						GIDs:  []uint32{2},
-						UIDs:  []uint32{102},
-						FTs:   expectedFTsBam,
+						Dir:     projectB125,
+						Count:   1,
+						Size:    20,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtime,
+						GIDs:    []uint32{2},
+						UIDs:    []uint32{102},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 				})
 			})
@@ -161,14 +169,15 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 				So(err, ShouldBeNil)
 				So(dcss, ShouldResemble, dgut.DCSs{
 					{
-						Dir:   projectA,
-						Count: 2,
-						Size:  halfGig + twoGig,
-						Atime: expectedAtime,
-						Mtime: expectedMtimeA,
-						GIDs:  []uint32{1},
-						UIDs:  []uint32{101},
-						FTs:   expectedFTsBam,
+						Dir:     projectA,
+						Count:   2,
+						Size:    halfGig + twoGig,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtimeA,
+						GIDs:    []uint32{1},
+						UIDs:    []uint32{101},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 				})
 
@@ -176,42 +185,44 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 				So(err, ShouldBeNil)
 				So(dcss, ShouldResemble, dgut.DCSs{
 					{
-						Dir:   projectB123,
-						Count: 1,
-						Size:  30,
-						Atime: expectedAtime,
-						Mtime: expectedMtime,
-						GIDs:  []uint32{2},
-						UIDs:  []uint32{102},
-						FTs:   expectedFTsBam,
+						Dir:     projectB123,
+						Count:   1,
+						Size:    30,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtime,
+						GIDs:    []uint32{2},
+						UIDs:    []uint32{102},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 					{
-						Dir:   projectB125,
-						Count: 1,
-						Size:  20,
-						Atime: expectedAtime,
-						Mtime: expectedMtime,
-						GIDs:  []uint32{2},
-						UIDs:  []uint32{102},
-						FTs:   expectedFTsBam,
+						Dir:     projectB125,
+						Count:   1,
+						Size:    20,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtime,
+						GIDs:    []uint32{2},
+						UIDs:    []uint32{102},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 					{
-						Dir:   user2,
-						Count: 1,
-						Size:  60,
-						Atime: expectedAtime,
-						Mtime: expectedMtime,
-						GIDs:  []uint32{77777},
-						UIDs:  []uint32{102},
-						FTs:   expectedFTsBam,
+						Dir:     user2,
+						Count:   1,
+						Size:    60,
+						Atime:   expectedAtime,
+						Mtime:   expectedMtime,
+						GIDs:    []uint32{77777},
+						UIDs:    []uint32{102},
+						FTs:     expectedFTsBam,
+						Modtime: dbModTime,
 					},
 				})
 			})
 		})
 
 		Convey("With which you can store group and user summary info in a database", func() {
-			yesterday := fixtimes.FixTime(time.Now().Add(-24 * time.Hour))
-			err := bd.CreateDatabase(yesterday)
+			err := bd.CreateDatabase()
 			So(err, ShouldBeNil)
 
 			_, err = os.Stat(dbPath)
@@ -366,6 +377,73 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 					err = bdr.Close()
 					So(err, ShouldBeNil)
 
+					Convey("then adding the same database twice doesn't duplicate history.", func() {
+						// Add existing…
+						bd, err = NewCreator(dbPath, splits, minDirs, tree, quotas)
+						So(err, ShouldBeNil)
+						So(bd, ShouldNotBeNil)
+
+						err = bd.CreateDatabase()
+						So(err, ShouldBeNil)
+
+						bdr, err = NewReader(dbPath, ownersPath)
+						So(err, ShouldBeNil)
+
+						history, err = bdr.History(1, projectA)
+						fixHistoryTimes(history)
+						So(err, ShouldBeNil)
+
+						So(len(history), ShouldEqual, 1)
+
+						err = bdr.Close()
+						So(err, ShouldBeNil)
+
+						// Add existing again…
+						bd, err = NewCreator(dbPath, splits, minDirs, tree, quotas)
+						So(err, ShouldBeNil)
+						So(bd, ShouldNotBeNil)
+
+						err = bd.CreateDatabase()
+						So(err, ShouldBeNil)
+
+						bdr, err = NewReader(dbPath, ownersPath)
+						So(err, ShouldBeNil)
+
+						history, err = bdr.History(1, projectA)
+						fixHistoryTimes(history)
+						So(err, ShouldBeNil)
+
+						So(len(history), ShouldEqual, 1)
+
+						err = bdr.Close()
+						So(err, ShouldBeNil)
+
+						// Add new…
+						fs.Touch(treePath, time.Now())
+
+						tree, err = dgut.NewTree(treePath)
+						So(err, ShouldBeNil)
+
+						bd, err = NewCreator(dbPath, splits, minDirs, tree, quotas)
+						So(err, ShouldBeNil)
+						So(bd, ShouldNotBeNil)
+
+						err = bd.CreateDatabase()
+						So(err, ShouldBeNil)
+
+						bdr, err = NewReader(dbPath, ownersPath)
+						So(err, ShouldBeNil)
+
+						history, err = bdr.History(1, projectA)
+						fixHistoryTimes(history)
+						So(err, ShouldBeNil)
+
+						So(len(history), ShouldEqual, 2)
+
+						err = bdr.Close()
+						So(err, ShouldBeNil)
+					})
+
 					Convey("Then you can add and retrieve a new day's usage and quota", func() {
 						_, files := internaldata.FakeFilesForDGUTDBForBasedirsTesting(gid, uid)
 						files[0].NumFiles = 2
@@ -373,7 +451,8 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 						files[1].SizeOfEachFile = twoGig
 
 						files = files[:len(files)-1]
-						tree, err = internaldb.CreateDGUTDBFromFakeFiles(t, files)
+						today := fixtimes.FixTime(time.Now())
+						tree, _, err = internaldb.CreateDGUTDBFromFakeFiles(t, files, today)
 						So(err, ShouldBeNil)
 
 						const fiveGig = 5 * (1 << 30)
@@ -389,8 +468,7 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 
 						bd.mountPoints = mp
 
-						today := fixtimes.FixTime(time.Now())
-						err := bd.CreateDatabase(today)
+						err := bd.CreateDatabase()
 						So(err, ShouldBeNil)
 
 						bdr, err = NewReader(dbPath, ownersPath)
@@ -823,7 +901,7 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 					newFiles[i].Path = "/nfs" + newFiles[i].Path[7:]
 				}
 
-				newTree, err := internaldb.CreateDGUTDBFromFakeFiles(t, newFiles)
+				newTree, _, err := internaldb.CreateDGUTDBFromFakeFiles(t, newFiles, yesterday)
 				So(err, ShouldBeNil)
 
 				newDBPath := filepath.Join(dir, "newdir.db")
@@ -837,7 +915,7 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 					"/nfs/scratch125/",
 				}
 
-				err = newBd.CreateDatabase(yesterday)
+				err = newBd.CreateDatabase()
 				So(err, ShouldBeNil)
 
 				outputDBPath := filepath.Join(dir, "merged.db")

--- a/basedirs/basedirs_test.go
+++ b/basedirs/basedirs_test.go
@@ -845,9 +845,7 @@ func TestBaseDirs(t *testing.T) { //nolint:gocognit
 				err = MergeDBs(dbPath, newDBPath, outputDBPath)
 				So(err, ShouldBeNil)
 
-				db, err := bolt.Open(outputDBPath, dbOpenMode, &bolt.Options{
-					ReadOnly: true,
-				})
+				db, err := openRODB(outputDBPath)
 
 				So(err, ShouldBeNil)
 				defer db.Close()

--- a/basedirs/db.go
+++ b/basedirs/db.go
@@ -81,9 +81,6 @@ type Usage struct {
 
 // CreateDatabase creates a database containing usage information for each of
 // our groups and users by calculated base directory.
-//
-// Provide a time that will be used as the date when appending to the historical
-// data.
 func (b *BaseDirs) CreateDatabase() error {
 	db, err := openDB(b.dbPath)
 	if err != nil {

--- a/basedirs/reader.go
+++ b/basedirs/reader.go
@@ -57,9 +57,7 @@ type BaseDirReader struct {
 // stored in a BaseDir database. It takes an owners file (gid,name csv) to
 // associate groups with their owners in certain output.
 func NewReader(dbPath, ownersPath string) (*BaseDirReader, error) {
-	db, err := bolt.Open(dbPath, dbOpenMode, &bolt.Options{
-		ReadOnly: true,
-	})
+	db, err := openRODB(dbPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/basedir.go
+++ b/cmd/basedir.go
@@ -162,7 +162,7 @@ be blank), and the first column will be user_name instead of group_name.
 		}
 
 		t = time.Now()
-		err = bd.CreateDatabase(time.Now())
+		err = bd.CreateDatabase()
 		if err != nil {
 			die("failed to create base directories database: %s", err)
 		}

--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -109,7 +109,9 @@ you supplied 'wrstat walk'.`,
 
 		wg.Wait()
 
-		neaten.CreateFile(filepath.Join(sourceDir, merge.SentinelComplete))
+		if err := neaten.CreateFile(filepath.Join(sourceDir, merge.SentinelComplete)); err != nil {
+			die("could not create sentinel completion file: %s", err)
+		}
 	},
 }
 

--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -32,6 +32,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wtsi-ssg/wrstat/v4/combine"
 	"github.com/wtsi-ssg/wrstat/v4/fs"
+	"github.com/wtsi-ssg/wrstat/v4/merge"
+	"github.com/wtsi-ssg/wrstat/v4/neaten"
 )
 
 const combineStatsOutputFileBasename = "combine.stats.gz"
@@ -106,6 +108,8 @@ you supplied 'wrstat walk'.`,
 		}()
 
 		wg.Wait()
+
+		neaten.CreateFile(filepath.Join(sourceDir, merge.SentinelComplete))
 	},
 }
 

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -96,6 +96,12 @@ func init() {
 	// flags specific to this sub-command
 	cronCmd.Flags().StringVarP(&workDir, "working_directory", "w", "", "base directory for intermediate results")
 	cronCmd.Flags().StringVarP(&finalDir, "final_output", "f", "", "final output directory")
+	cronCmd.Flags().StringVarP(&partialDirMerge, "partial_dir_merge", "c", "", "merge results from a partial run"+
+		"stored in the specified directory")
+	cronCmd.Flags().BoolVarP(&partialDirClean, "partial_dir_clean", "r", false, "remove old results "+
+		"from specified directory after merging")
+	cronCmd.Flags().BoolVarP(&createPartial, "create_partial_dir", "p", false, "perform the walk, "+
+		"stat, and combine steps only")
 	cronCmd.Flags().IntVarP(&multiInodes, "inodes_per_stat", "n",
 		defaultInodesPerJob, "number of inodes per parallel stat job")
 	cronCmd.Flags().IntVarP(&multiStatJobs, "num_stat_jobs", "j",

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -39,8 +39,10 @@ import (
 )
 
 // options for this cmd.
-var crontab string
-var cronKill bool
+var (
+	crontab  string
+	cronKill bool
+)
 
 // cronCmd represents the cron command.
 var cronCmd = &cobra.Command{
@@ -96,7 +98,7 @@ func init() {
 	// flags specific to this sub-command
 	cronCmd.Flags().StringVarP(&workDir, "working_directory", "w", "", "base directory for intermediate results")
 	cronCmd.Flags().StringVarP(&finalDir, "final_output", "f", "", "final output directory")
-	cronCmd.Flags().StringVarP(&partialDirMerge, "partial_dir_merge", "c", "", "merge results from a partial run"+
+	cronCmd.Flags().StringVarP(&partialDirMerge, "partial_dir_merge", "l", "", "merge results from a partial run"+
 		"stored in the specified directory")
 	cronCmd.Flags().BoolVarP(&partialDirClean, "partial_dir_clean", "r", false, "remove old results "+
 		"from specified directory after merging")

--- a/cmd/mergedbs.go
+++ b/cmd/mergedbs.go
@@ -47,8 +47,8 @@ directory of a full 'wrstat multi' run.
 Provide the output working directory of the minimal '-p' run and the unique
 working directory of the full multi run.
 
- Provide the --delete option to delete all previous runs within the minimal
- working directory, leaving the latest.`,
+Provide the --delete option to delete all previous runs within the minimal
+working directory, leaving the latest.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != mergeArgs {
 			die("exactly 2 output directories from 'wrstat multi' must be supplied")

--- a/cmd/mergedbs.go
+++ b/cmd/mergedbs.go
@@ -26,22 +26,11 @@
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-	"time"
-
 	"github.com/spf13/cobra"
-	"github.com/wtsi-ssg/wrstat/v4/basedirs"
-	"github.com/wtsi-ssg/wrstat/v4/neaten"
-	"github.com/wtsi-ssg/wrstat/v4/wait"
+	"github.com/wtsi-ssg/wrstat/v4/merge"
 )
 
-const (
-	mergeArgs             = 2
-	mergeDatePrefixLength = 8
-	mergeMaxWait          = 23 * time.Hour
-	reloadGrace           = 15 * time.Minute
-)
+const mergeArgs = 2
 
 // options for this cmd.
 var mergeDelete bool
@@ -51,84 +40,22 @@ var mergedbsCmd = &cobra.Command{
 	Use:   "mergedbs",
 	Short: "Merge wrstat databases.",
 	Long: `Merge wrstat databases.
- 
- If you run 'wrstat multi' on 2 separate systems but want to combine their
- outputs to display on a single wrstat server, use this command to merge their
- databases.
- 
- Provide the multi output directories of the 2 systems. The most recent database
- information in the first will be copied/merged in to the most recent set with
- the same date prefix in the second one, and then the second one's
- .dgut.dbs.updated will be touched to trigger any running server monitoring the
- second one's dbs to reload.
- 
- This will wait up to 23hrs for both folder's most recent database files have
- the same date prefix.
- 
- To avoid doing the merge in the middle of a server doing a database reload,
- waits until it is more than 15mins since the second's .dgut.dbs.updated was
- touched
- 
- This means you can run multi on your 2 systems once per day, and run this in
- a crontab job once per day as well, and it will merge the 2 outputs of the
- same day once they're both ready.
 
- Provide the --delete option to delete all files with the database's date
- prefix from the first output directory after successful merge.
- .`,
+Used to merge in results from a minimal 'wrstat multi -p' run into the working
+directory of a full 'wrstat multi' run.
+
+Provide the output working directory of the minimal '-p' run and the unique
+working directory of the full multi run.
+
+ Provide the --delete option to delete all previous runs within the minimal
+ working directory, leaving the latest.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != mergeArgs {
 			die("exactly 2 output directories from 'wrstat multi' must be supplied")
 		}
 
-		sourceDir, destDir := args[0], args[1]
-
-		sourceDGUTDir, destDGUTDir, err := wait.ForMatchingPrefixOfLatestSuffix(
-			dgutDBsSuffix, mergeDatePrefixLength, sourceDir, destDir, mergeMaxWait)
-		if err != nil {
-			die("wait for matching dgut.db outputs failed: %s", err)
-		}
-
-		err = neaten.MergeDGUTDBDirectories(sourceDGUTDir, destDGUTDir)
-		if err != nil {
-			die("merge of dgut.db directories failed: %s", err)
-		}
-
-		sourceBasedir, destBasedir, err := wait.ForMatchingPrefixOfLatestSuffix(
-			basedirBasename, mergeDatePrefixLength, sourceDir, destDir, mergeMaxWait)
-		if err != nil {
-			die("wait for matching basedirs outputs failed: %s", err)
-		}
-
-		outputDBPath := destBasedir + ".merging"
-
-		err = basedirs.MergeDBs(sourceBasedir, destBasedir, outputDBPath)
-		if err != nil {
-			die("merge of basedir.dbs failed: %s", err)
-		}
-
-		sentinal := filepath.Join(destDir, dgutDBsSentinelBasename)
-
-		err = wait.UntilFileIsOld(sentinal, reloadGrace)
-		if err != nil {
-			die("waiting for the dgutdbs sentintal file failed: %s", err)
-		}
-
-		err = os.Rename(outputDBPath, destBasedir)
-		if err != nil {
-			die("failed to move the merged basedirs.db file back over original: %s", err)
-		}
-
-		err = neaten.Touch(sentinal)
-		if err != nil {
-			die("failed to touch the dgutdbs sentinal file: %s", err)
-		}
-
-		if mergeDelete {
-			err = neaten.DeleteAllPrefixedDirEntries(sourceDir, filepath.Base(sourceBasedir)[:mergeDatePrefixLength])
-			if err != nil {
-				warn("failed to delete source files: %s", err)
-			}
+		if err := merge.Merge(args[0], args[1], mergeDelete); err != nil {
+			die("error while merging: %s", err)
 		}
 	},
 }

--- a/cmd/multi.go
+++ b/cmd/multi.go
@@ -181,17 +181,7 @@ func checkMultiArgs(args []string) {
 	}
 
 	if !createCustom {
-		if finalDir == "" {
-			die("--final_output is required")
-		}
-
-		if quota == "" {
-			die("--quota is required")
-		}
-
-		if ownersPath == "" {
-			die("--owners is required")
-		}
+		checkStandardFlags()
 	}
 
 	if len(args) == 0 {
@@ -204,6 +194,20 @@ func checkMultiArgs(args []string) {
 
 	if multiMinDirs <= 0 {
 		die("minimum number of dirs must be an integer more than 0")
+	}
+}
+
+func checkStandardFlags() {
+	if finalDir == "" {
+		die("--final_output is required")
+	}
+
+	if quota == "" {
+		die("--quota is required")
+	}
+
+	if ownersPath == "" {
+		die("--owners is required")
 	}
 }
 

--- a/cmd/multi.go
+++ b/cmd/multi.go
@@ -154,8 +154,10 @@ func init() {
 	multiCmd.Flags().StringVarP(&workDir, "working_directory", "w", "", "base directory for intermediate results")
 	multiCmd.Flags().StringVarP(&finalDir, "final_output", "f", "", "final output directory")
 	multiCmd.Flags().StringVarP(&customDirMerge, "custom_dir_merge", "c", "", "merge results from specified directory")
-	multiCmd.Flags().BoolVarP(&customDirClean, "custom_dir_clean", "r", false, "remove old results from specified directory after merging")
-	multiCmd.Flags().BoolVarP(&createCustom, "create_custom_dir", "p", false, "perform the walk, stat, and combine steps only")
+	multiCmd.Flags().BoolVarP(&customDirClean, "custom_dir_clean", "r", false, "remove old results "+
+		"from specified directory after merging")
+	multiCmd.Flags().BoolVarP(&createCustom, "create_custom_dir", "p", false, "perform the walk, "+
+		"stat, and combine steps only")
 	multiCmd.Flags().IntVarP(&multiInodes, "inodes_per_stat", "n",
 		defaultInodesPerJob, "number of inodes per parallel stat job")
 	multiCmd.Flags().IntVarP(&multiStatJobs, "num_stat_jobs", "j",

--- a/cmd/multi.go
+++ b/cmd/multi.go
@@ -155,7 +155,7 @@ func init() {
 	// flags specific to this sub-command
 	multiCmd.Flags().StringVarP(&workDir, "working_directory", "w", "", "base directory for intermediate results")
 	multiCmd.Flags().StringVarP(&finalDir, "final_output", "f", "", "final output directory")
-	multiCmd.Flags().StringVarP(&partialDirMerge, "partial_dir_merge", "c", "", "merge results from a partial run"+
+	multiCmd.Flags().StringVarP(&partialDirMerge, "partial_dir_merge", "l", "", "merge results from a partial run"+
 		"stored in the specified directory")
 	multiCmd.Flags().BoolVarP(&partialDirClean, "partial_dir_clean", "r", false, "remove old results "+
 		"from specified directory after merging")

--- a/cmd/multi.go
+++ b/cmd/multi.go
@@ -49,19 +49,21 @@ const (
 )
 
 // options for this cmd.
-var workDir string
-var finalDir string
-var customDirMerge string
-var customDirClean bool
-var createCustom bool
-var multiInodes int
-var multiStatJobs int
-var multiCh string
-var forcedQueue string
-var quota string
-var maxMem int
-var multiSplits int
-var multiMinDirs int
+var (
+	workDir        string
+	finalDir       string
+	customDirMerge string
+	customDirClean bool
+	createCustom   bool
+	multiInodes    int
+	multiStatJobs  int
+	multiCh        string
+	forcedQueue    string
+	quota          string
+	maxMem         int
+	multiSplits    int
+	multiMinDirs   int
+)
 
 // multiCmd represents the multi command.
 var multiCmd = &cobra.Command{
@@ -178,16 +180,18 @@ func checkMultiArgs(args []string) {
 		die("--working_directory is required")
 	}
 
-	if finalDir == "" {
-		die("--final_output is required")
-	}
+	if !createCustom {
+		if finalDir == "" {
+			die("--final_output is required")
+		}
 
-	if quota == "" {
-		die("--quota is required")
-	}
+		if quota == "" {
+			die("--quota is required")
+		}
 
-	if ownersPath == "" {
-		die("--owners is required")
+		if ownersPath == "" {
+			die("--owners is required")
+		}
 	}
 
 	if len(args) == 0 {
@@ -234,7 +238,8 @@ func doMultiScheduling(args []string) error {
 // path. The second scheduler is used to add combine jobs, which need a memory
 // override.
 func scheduleWalkJobs(outputRoot string, desiredPaths []string, unique string,
-	numStatJobs, inodesPerStat int, yamlPath, queue string, s *scheduler.Scheduler) {
+	numStatJobs, inodesPerStat int, yamlPath, queue string, s *scheduler.Scheduler,
+) {
 	walkJobs := make([]*jobqueue.Job, len(desiredPaths))
 	combineJobs := make([]*jobqueue.Job, len(desiredPaths))
 
@@ -331,7 +336,7 @@ func scheduleStaticCopy(outputRoot, unique, customDirMerge string, customDirClea
 	var remove string
 
 	if customDirClean {
-		remove = "--remove"
+		remove = "--delete"
 	}
 
 	job := s.NewJob(fmt.Sprintf("%s mergedbs %s %q %q",

--- a/combine/dgut_test.go
+++ b/combine/dgut_test.go
@@ -60,7 +60,7 @@ func TestDGUTFiles(t *testing.T) {
 				err = db.Open()
 				So(err, ShouldBeNil)
 
-				numFiles, fileSize, aTime, mTime, users, groups, fileType, err := db.DirInfo("/", nil)
+				numFiles, fileSize, aTime, mTime, users, groups, fileType, _, err := db.DirInfo("/", nil)
 				So(err, ShouldBeNil)
 				So(numFiles, ShouldEqual, 3)
 				So(fileSize, ShouldEqual, 25)

--- a/dgut/dgut_test.go
+++ b/dgut/dgut_test.go
@@ -250,7 +250,7 @@ func TestDGUT(t *testing.T) {
 						err = db.Open()
 						So(err, ShouldBeNil)
 
-						c, s, a, m, u, g, t, errd := db.DirInfo("/", nil)
+						c, s, a, m, u, g, t, _, errd := db.DirInfo("/", nil)
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 14+numDirectories)
 						So(s, ShouldEqual, 85+numDirectories*directorySize)
@@ -260,7 +260,7 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, expectedGIDs)
 						So(t, ShouldResemble, expectedFTs)
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/a/c/d", nil)
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/a/c/d", nil)
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 6)
 						So(s, ShouldEqual, 5+directorySize)
@@ -270,7 +270,7 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, []uint32{2})
 						So(t, ShouldResemble, []summary.DirGUTFileType{summary.DGUTFileTypeCram, summary.DGUTFileTypeDir})
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/a/b/d/g", nil)
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/a/b/d/g", nil)
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 7)
 						So(s, ShouldEqual, 60+directorySize)
@@ -280,11 +280,11 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, []uint32{1})
 						So(t, ShouldResemble, []summary.DirGUTFileType{summary.DGUTFileTypeCram, summary.DGUTFileTypeDir})
 
-						_, _, _, _, _, _, _, errd = db.DirInfo("/foo", nil)
+						_, _, _, _, _, _, _, _, errd = db.DirInfo("/foo", nil)
 						So(errd, ShouldNotBeNil)
 						So(errd, ShouldEqual, ErrDirNotFound)
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/", &Filter{GIDs: []uint32{1}})
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/", &Filter{GIDs: []uint32{1}})
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 9+8)
 						So(s, ShouldEqual, 80+8*directorySize)
@@ -294,7 +294,7 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, []uint32{1})
 						So(t, ShouldResemble, expectedFTs)
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/", &Filter{UIDs: []uint32{102}})
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/", &Filter{UIDs: []uint32{102}})
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 9+2)
 						So(s, ShouldEqual, 45+2*directorySize)
@@ -304,7 +304,7 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, expectedGIDs)
 						So(t, ShouldResemble, []summary.DirGUTFileType{summary.DGUTFileTypeCram, summary.DGUTFileTypeDir})
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/", &Filter{GIDs: []uint32{1}, UIDs: []uint32{102}})
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/", &Filter{GIDs: []uint32{1}, UIDs: []uint32{102}})
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 4)
 						So(s, ShouldEqual, 40)
@@ -314,7 +314,7 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, []uint32{1})
 						So(t, ShouldResemble, []summary.DirGUTFileType{summary.DGUTFileTypeCram})
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/", &Filter{
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/", &Filter{
 							GIDs: []uint32{1},
 							UIDs: []uint32{102},
 							FTs:  []summary.DirGUTFileType{summary.DGUTFileTypeTemp}})
@@ -327,7 +327,7 @@ func TestDGUT(t *testing.T) {
 						So(g, ShouldResemble, []uint32{})
 						So(t, ShouldResemble, []summary.DirGUTFileType{})
 
-						c, s, a, m, u, g, t, errd = db.DirInfo("/", &Filter{FTs: []summary.DirGUTFileType{summary.DGUTFileTypeTemp}})
+						c, s, a, m, u, g, t, _, errd = db.DirInfo("/", &Filter{FTs: []summary.DirGUTFileType{summary.DGUTFileTypeTemp}})
 						So(errd, ShouldBeNil)
 						So(c, ShouldEqual, 1+1)
 						So(s, ShouldEqual, 5+directorySize)
@@ -399,7 +399,7 @@ func TestDGUT(t *testing.T) {
 							err = db.Open()
 							So(err, ShouldBeNil)
 
-							c, s, a, m, u, g, t, errd := db.DirInfo("/", nil)
+							c, s, a, m, u, g, t, _, errd := db.DirInfo("/", nil)
 							So(errd, ShouldBeNil)
 							So(c, ShouldEqual, 16+numDirectories)
 							So(s, ShouldEqual, 87+numDirectories*directorySize)
@@ -614,7 +614,7 @@ func testMakeDBPaths(t *testing.T) []string {
 
 	dir := t.TempDir()
 
-	set := newDBSet(dir)
+	set, _ := newDBSet(dir)
 	paths := set.paths()
 
 	return append([]string{dir}, paths...)

--- a/dgut/dgut_test.go
+++ b/dgut/dgut_test.go
@@ -213,7 +213,9 @@ func TestDGUT(t *testing.T) {
 		})
 
 		Convey("And database file paths", func() {
-			paths := testMakeDBPaths(t)
+			paths, err := testMakeDBPaths(t)
+			So(err, ShouldBeNil)
+
 			db := NewDB(paths[0])
 			So(db, ShouldNotBeNil)
 
@@ -490,7 +492,9 @@ func TestDGUT(t *testing.T) {
 			err = db.Open()
 			So(err, ShouldNotBeNil)
 
-			paths := testMakeDBPaths(t)
+			paths, err := testMakeDBPaths(t)
+			So(err, ShouldBeNil)
+
 			db = NewDB(paths[0])
 
 			err = os.WriteFile(paths[2], []byte("foo"), 0600)
@@ -609,15 +613,19 @@ func testData(t *testing.T) (dgutData string, expectedRootGUTs GUTs, expected []
 // testMakeDBPaths creates a temp dir that will be cleaned up automatically, and
 // returns the paths to the directory and dgut and children database files
 // inside that would be created. The files aren't actually created.
-func testMakeDBPaths(t *testing.T) []string {
+func testMakeDBPaths(t *testing.T) ([]string, error) {
 	t.Helper()
 
 	dir := t.TempDir()
 
-	set, _ := newDBSet(dir)
+	set, err := newDBSet(dir)
+	if err != nil {
+		return nil, err
+	}
+
 	paths := set.paths()
 
-	return append([]string{dir}, paths...)
+	return append([]string{dir}, paths...), nil
 }
 
 // testGetDBKeys returns all the keys in the db at the given path.

--- a/dgut/tree.go
+++ b/dgut/tree.go
@@ -54,14 +54,15 @@ func NewTree(paths ...string) (*Tree, error) {
 // directory. It also holds which users and groups own files nested under the
 // directory, and what the file types are.
 type DirSummary struct {
-	Dir   string
-	Count uint64
-	Size  uint64
-	Atime time.Time
-	Mtime time.Time
-	UIDs  []uint32
-	GIDs  []uint32
-	FTs   []summary.DirGUTFileType
+	Dir     string
+	Count   uint64
+	Size    uint64
+	Atime   time.Time
+	Mtime   time.Time
+	UIDs    []uint32
+	GIDs    []uint32
+	FTs     []summary.DirGUTFileType
+	Modtime time.Time
 }
 
 // DCSs is a Size-sortable slice of DirSummary.
@@ -143,20 +144,21 @@ func (t *Tree) DirHasChildren(dir string, filter *Filter) bool {
 // info for a given directory and filter, along with the UIDs and GIDs that own
 // those files, the file types of those files.
 func (t *Tree) getSummaryInfo(dir string, filter *Filter) (*DirSummary, error) {
-	c, s, a, m, u, g, fts, err := t.db.DirInfo(dir, filter)
+	c, s, a, m, u, g, fts, lastUpdated, err := t.db.DirInfo(dir, filter)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DirSummary{
-		Dir:   dir,
-		Count: c,
-		Size:  s,
-		Atime: time.Unix(a, 0),
-		Mtime: time.Unix(m, 0),
-		UIDs:  u,
-		GIDs:  g,
-		FTs:   fts,
+		Dir:     dir,
+		Count:   c,
+		Size:    s,
+		Atime:   time.Unix(a, 0),
+		Mtime:   time.Unix(m, 0),
+		UIDs:    u,
+		GIDs:    g,
+		FTs:     fts,
+		Modtime: lastUpdated,
 	}, nil
 }
 

--- a/dgut/tree_test.go
+++ b/dgut/tree_test.go
@@ -40,7 +40,9 @@ func TestTree(t *testing.T) {
 	expectedFTsBam := []summary.DirGUTFileType{summary.DGUTFileTypeBam}
 
 	Convey("You can make a Tree from a dgut database", t, func() {
-		paths := testMakeDBPaths(t)
+		paths, err := testMakeDBPaths(t)
+		So(err, ShouldBeNil)
+
 		tree, errc := NewTree(paths[0])
 		So(errc, ShouldNotBeNil)
 		So(tree, ShouldBeNil)
@@ -217,17 +219,21 @@ func TestTree(t *testing.T) {
 	})
 
 	Convey("You can make a Tree from multiple dgut databases and query it", t, func() {
-		paths1 := testMakeDBPaths(t)
+		paths1, err := testMakeDBPaths(t)
+		So(err, ShouldBeNil)
+
 		db := NewDB(paths1[0])
 		data := strings.NewReader("/\t1\t11\t6\t1\t1\t20\t20\n" +
 			"/a\t1\t11\t6\t1\t1\t20\t20\n" +
 			"/a/b\t1\t11\t6\t1\t1\t20\t20\n" +
 			"/a/b/c\t1\t11\t6\t1\t1\t20\t20\n" +
 			"/a/b/c/d\t1\t11\t6\t1\t1\t20\t20\n")
-		err := db.Store(data, 20)
+		err = db.Store(data, 20)
 		So(err, ShouldBeNil)
 
-		paths2 := testMakeDBPaths(t)
+		paths2, err := testMakeDBPaths(t)
+		So(err, ShouldBeNil)
+
 		db = NewDB(paths2[0])
 		data = strings.NewReader("/\t1\t11\t6\t1\t1\t15\t15\n" +
 			"/a\t1\t11\t6\t1\t1\t15\t15\n" +

--- a/dgut/tree_test.go
+++ b/dgut/tree_test.go
@@ -250,7 +250,6 @@ func TestTree(t *testing.T) {
 		expectedAtime := time.Unix(15, 0)
 		expectedMtime := time.Unix(20, 0)
 
-		//mtime1 := fs.ModTime(paths1[0])
 		mtime2 := fs.ModTime(paths2[0])
 
 		dcss, err := tree.Where("/", nil, 0)

--- a/internal/db/basedirs.go
+++ b/internal/db/basedirs.go
@@ -46,7 +46,7 @@ func CreateExampleDGUTDBForBasedirs(t *testing.T) (*dgut.Tree, []string, error) 
 
 	dirs, files := internaldata.FakeFilesForDGUTDBForBasedirsTesting(gid, uid)
 
-	tree, err := CreateDGUTDBFromFakeFiles(t, files)
+	tree, _, err := CreateDGUTDBFromFakeFiles(t, files)
 
 	return tree, dirs, err
 }

--- a/internal/db/dgut.go
+++ b/internal/db/dgut.go
@@ -41,7 +41,7 @@ import (
 	"github.com/wtsi-ssg/wrstat/v4/internal/fs"
 )
 
-const DirPerms = 0755
+const DirPerms = fs.DirPerms
 const ExampleDgutDirParentSuffix = "dgut.dbs"
 const minGIDsForExampleDgutDB = 2
 const exampleDBBatchSize = 20

--- a/internal/db/dgut.go
+++ b/internal/db/dgut.go
@@ -34,9 +34,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wtsi-ssg/wrstat/v4/dgut"
 	internaldata "github.com/wtsi-ssg/wrstat/v4/internal/data"
+	"github.com/wtsi-ssg/wrstat/v4/internal/fs"
 )
 
 const DirPerms = 0755
@@ -122,7 +124,8 @@ func exampleDGUTData(t *testing.T, uidStr, gidAStr, gidBStr string) string {
 	return internaldata.TestDGUTData(t, internaldata.CreateDefaultTestData(int(gidA), int(gidB), 0, int(uid), 0))
 }
 
-func CreateDGUTDBFromFakeFiles(t *testing.T, files []internaldata.TestFile) (*dgut.Tree, error) {
+func CreateDGUTDBFromFakeFiles(t *testing.T, files []internaldata.TestFile,
+	modtime ...time.Time) (*dgut.Tree, string, error) {
 	t.Helper()
 
 	dgutData := internaldata.TestDGUTData(t, files)
@@ -132,7 +135,11 @@ func CreateDGUTDBFromFakeFiles(t *testing.T, files []internaldata.TestFile) (*dg
 		t.Fatalf("could not create dgut db: %s", err)
 	}
 
+	if len(modtime) == 1 {
+		fs.Touch(dbPath, modtime[0])
+	}
+
 	tree, err := dgut.NewTree(dbPath)
 
-	return tree, err
+	return tree, dbPath, err
 }

--- a/internal/db/dgut.go
+++ b/internal/db/dgut.go
@@ -136,7 +136,9 @@ func CreateDGUTDBFromFakeFiles(t *testing.T, files []internaldata.TestFile,
 	}
 
 	if len(modtime) == 1 {
-		fs.Touch(dbPath, modtime[0])
+		if err = fs.Touch(dbPath, modtime[0]); err != nil {
+			return nil, "", err
+		}
 	}
 
 	tree, err := dgut.NewTree(dbPath)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -83,6 +83,6 @@ func ModTime(path string) time.Time {
 
 // Touch updates the modtime and access time of the specified path to the
 // specified time.
-func Touch(path string, t time.Time) {
-	os.Chtimes(path, t, t)
+func Touch(path string, t time.Time) error {
+	return os.Chtimes(path, t, t)
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -70,3 +70,19 @@ func DirEntryModTime(de os.DirEntry) time.Time {
 
 	return info.ModTime()
 }
+
+// ModTime returns the ModTime for the given path, treating errors as time 0.
+func ModTime(path string) time.Time {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return time.Time{}
+	}
+
+	return fi.ModTime()
+}
+
+// Touch updates the modtime and access time of the specified path to the
+// specified time.
+func Touch(path string, t time.Time) {
+	os.Chtimes(path, t, t)
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -92,7 +92,8 @@ type pathTime struct {
 	modtime time.Time
 }
 
-// FindLatestCombinedOutputOlderThan finds the latest entry in dir and returns its path.
+// FindLatestCombinedOutputOlderThan finds the latest entry in dir, waits for it
+// to be the given age, then returns its path.
 func FindLatestCombinedOutputOlderThan(dir, watchFile string, minAge time.Duration) (string, error) {
 	for {
 		files, err := filepath.Glob(filepath.Join(dir, "*", "*", "*", watchFile))

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -1,0 +1,184 @@
+package merge
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	internaldb "github.com/wtsi-ssg/wrstat/v4/internal/db"
+	ifs "github.com/wtsi-ssg/wrstat/v4/internal/fs"
+)
+
+const (
+	reloadGrace = 5 * time.Minute
+	watchFile   = "combine.log.gz"
+)
+
+func Merge(sourceDir, destDir string, removeOld bool) error {
+	de, err := FindLatestCombinedOutputOlderThan(sourceDir, reloadGrace)
+	if err != nil {
+		return fmt.Errorf("failed to find database files in source dir: %w", err)
+	}
+
+	if err = copyPreservingTimestamp(de, destDir); err != nil {
+		return fmt.Errorf("failed to copy files to new dest: %w", err)
+	}
+
+	if !removeOld {
+		return nil
+	}
+
+	fi, err := os.Lstat(de)
+	if err != nil {
+		return fmt.Errorf("failed to stat latest directory (%s): %w", de, err)
+	}
+
+	if err := removeFromDirWhenOlderThan(sourceDir, fi.ModTime()); err != nil {
+		return fmt.Errorf("failed to remove old source files: %w", err)
+	}
+
+	return nil
+}
+
+type pathTime struct {
+	path    string
+	modtime time.Time
+}
+
+// FindLatestCombinedOutputOlderThan finds the latest entry in dir and returns its path.
+func FindLatestCombinedOutputOlderThan(dir string, minAge time.Duration) (string, error) {
+	for {
+		files, err := filepath.Glob(filepath.Join(dir, "*", "*", watchFile))
+		if err != nil {
+			return "", err
+		}
+
+		if len(files) == 0 {
+			return "", ifs.ErrNoDirEntryFound
+		}
+
+		de, err := filesToLatestPathTime(files)
+		if err != nil {
+			return "", err
+		}
+
+		diff := de.modtime.Sub(time.Now().Add(-minAge))
+
+		if diff < 0 {
+			return filepath.Dir(filepath.Dir(de.path)), nil
+		}
+
+		time.Sleep(diff)
+	}
+}
+
+func filesToLatestPathTime(files []string) (pathTime, error) {
+	des := make([]pathTime, len(files))
+
+	for n, file := range files {
+		fi, err := os.Lstat(file)
+		if err != nil {
+			return pathTime{}, err
+		}
+
+		des[n] = pathTime{
+			path:    file,
+			modtime: fi.ModTime(),
+		}
+	}
+
+	sort.Slice(des, func(i, j int) bool {
+		return des[i].modtime.After(des[j].modtime)
+	})
+
+	return des[0], nil
+}
+
+func copyPreservingTimestamp(source, dest string) error {
+	fi, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+
+	t := fi.ModTime()
+
+	if fi.IsDir() {
+		err = copyDirectoryPreservingTimestamp(source, dest)
+	} else {
+		err = copyFile(source, dest)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return os.Chtimes(dest, t, t)
+}
+
+func copyDirectoryPreservingTimestamp(source, dest string) error {
+	if err := os.MkdirAll(dest, internaldb.DirPerms); err != nil {
+		return err
+	}
+
+	matches, err := filepath.Glob(source + "/*")
+	if err != nil {
+		return err
+	}
+
+	for _, match := range matches {
+		if err := copyPreservingTimestamp(match, filepath.Join(dest, filepath.Base(match))); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyFile(source, dest string) (err error) {
+	var f, d *os.File
+
+	if f, err = os.Open(source); err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	if d, err = os.Create(dest); err != nil {
+		return err
+	}
+
+	defer func() {
+		if errr := d.Close(); err == nil {
+			err = errr
+		}
+	}()
+
+	_, err = io.Copy(d, f)
+
+	return err
+}
+
+func removeFromDirWhenOlderThan(dir string, before time.Time) error {
+	matches, err := filepath.Glob(dir + "/*")
+	if err != nil {
+		return err
+	}
+
+	for _, match := range matches {
+		fi, err := os.Lstat(match)
+		if err != nil {
+			return err
+		} else if !fi.ModTime().Before(before) {
+			continue
+		}
+
+		if err := os.RemoveAll(match); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -2,12 +2,9 @@ package merge
 
 import (
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 	"time"
 
-	internaldb "github.com/wtsi-ssg/wrstat/v4/internal/db"
 	"github.com/wtsi-ssg/wrstat/v4/internal/fs"
 )
 
@@ -27,7 +24,7 @@ func Merge(sourceDir, destDir string, removeOld bool) error {
 		return fmt.Errorf("failed to find database files in source dir: %w", err)
 	}
 
-	if err = copyPreservingTimestamp(de, destDir); err != nil {
+	if err = fs.CopyPreservingTimestamp(de, destDir); err != nil {
 		return fmt.Errorf("failed to copy files to new dest: %w", err)
 	}
 
@@ -40,94 +37,8 @@ func Merge(sourceDir, destDir string, removeOld bool) error {
 		return fmt.Errorf("failed to stat latest directory (%s): %w", de, err)
 	}
 
-	if err := removeFromDirWhenOlderThan(sourceDir, fi.ModTime()); err != nil {
+	if err := fs.RemoveFromDirWhenOlderThan(sourceDir, fi.ModTime()); err != nil {
 		return fmt.Errorf("failed to remove old source files: %w", err)
-	}
-
-	return nil
-}
-
-func copyPreservingTimestamp(source, dest string) error {
-	fi, err := os.Lstat(source)
-	if err != nil {
-		return err
-	}
-
-	t := fi.ModTime()
-
-	if fi.IsDir() {
-		err = copyDirectoryPreservingTimestamp(source, dest)
-	} else {
-		err = copyFile(source, dest)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return os.Chtimes(dest, t, t)
-}
-
-func copyDirectoryPreservingTimestamp(source, dest string) error {
-	if err := os.MkdirAll(dest, internaldb.DirPerms); err != nil {
-		return err
-	}
-
-	matches, err := filepath.Glob(source + "/*")
-	if err != nil {
-		return err
-	}
-
-	for _, match := range matches {
-		if err := copyPreservingTimestamp(match, filepath.Join(dest, filepath.Base(match))); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func copyFile(source, dest string) (err error) {
-	var f, d *os.File
-
-	if f, err = os.Open(source); err != nil {
-		return err
-	}
-
-	defer f.Close()
-
-	if d, err = os.Create(dest); err != nil {
-		return err
-	}
-
-	defer func() {
-		if errr := d.Close(); err == nil {
-			err = errr
-		}
-	}()
-
-	_, err = io.Copy(d, f)
-
-	return err
-}
-
-func removeFromDirWhenOlderThan(dir string, before time.Time) error {
-	matches, err := filepath.Glob(dir + "/*")
-	if err != nil {
-		return err
-	}
-
-	for _, match := range matches {
-		fi, err := os.Lstat(match)
-		if err != nil {
-			return err
-		} else if !fi.ModTime().Before(before) {
-			continue
-		}
-
-		if err := os.RemoveAll(match); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -51,7 +51,7 @@ type pathTime struct {
 // FindLatestCombinedOutputOlderThan finds the latest entry in dir and returns its path.
 func FindLatestCombinedOutputOlderThan(dir string, minAge time.Duration) (string, error) {
 	for {
-		files, err := filepath.Glob(filepath.Join(dir, "*", "*", watchFile))
+		files, err := filepath.Glob(filepath.Join(dir, "*", "*", "*", watchFile))
 		if err != nil {
 			return "", err
 		}
@@ -68,7 +68,7 @@ func FindLatestCombinedOutputOlderThan(dir string, minAge time.Duration) (string
 		diff := de.modtime.Sub(time.Now().Add(-minAge))
 
 		if diff < 0 {
-			return filepath.Dir(filepath.Dir(de.path)), nil
+			return filepath.Dir(filepath.Dir(filepath.Dir(de.path))), nil
 		}
 
 		time.Sleep(diff)

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	reloadGrace = 5 * time.Minute
-	watchFile   = "combine.log.gz"
+	reloadGrace      = 5 * time.Minute
+	SentinelComplete = "combine.complete"
 )
 
 func Merge(sourceDir, destDir string, removeOld bool) error {
-	de, err := fs.FindLatestCombinedOutputOlderThan(sourceDir, watchFile, reloadGrace)
+	de, err := fs.FindLatestCombinedOutputOlderThan(sourceDir, SentinelComplete, reloadGrace)
 	if err != nil {
 		return fmt.Errorf("failed to find database files in source dir: %w", err)
 	}

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -16,6 +16,11 @@ const (
 	SentinelComplete = "combine.complete"
 )
 
+// Merge finds the latest completed run in the source dir and copies it,
+// preserving timestamps, into the destination.
+//
+// When the removeOld param is set to true, the function will remove any runs
+// older that the one that is copied.
 func Merge(sourceDir, destDir string, removeOld bool) error {
 	de, err := fs.FindLatestCombinedOutputOlderThan(sourceDir, SentinelComplete, reloadGrace)
 	if err != nil {

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -104,7 +104,7 @@ func createDirStructure(base string, mt time.Time, extra ...string) error {
 		}
 	}
 
-	for _, file := range append(extra, "aFile", "a/notherFile", "b/d/e", "b/"+watchFile) {
+	for _, file := range append(extra, "aFile", "a/notherFile", "b/d/e", "b/d/"+watchFile) {
 		p := filepath.Join(base, file)
 
 		err := neaten.CreateFile(p)

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -67,7 +67,7 @@ func TestCopy(t *testing.T) {
 		err := createDirStructure(dir, time.Now().Add(time.Second*-10))
 		So(err, ShouldBeNil)
 
-		err = copyPreservingTimestamp(dir, newDir)
+		err = ifs.CopyPreservingTimestamp(dir, newDir)
 		So(err, ShouldBeNil)
 
 		err = fs.WalkDir(os.DirFS(dir), ".", func(path string, de fs.DirEntry, errr error) error {

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -1,0 +1,135 @@
+package merge
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/rs/xid"
+	. "github.com/smartystreets/goconvey/convey"
+	internaldb "github.com/wtsi-ssg/wrstat/v4/internal/db"
+	ifs "github.com/wtsi-ssg/wrstat/v4/internal/fs"
+	"github.com/wtsi-ssg/wrstat/v4/neaten"
+)
+
+func TestMerge(t *testing.T) {
+	Convey("", t, func() {
+		times := [...]time.Time{
+			time.Now().Add(-3 * time.Hour),
+			time.Now().Add(-2 * time.Hour),
+			time.Now().Add(-1 * time.Hour),
+		}
+		multiOutput := t.TempDir()
+		customOutput := t.TempDir()
+		multiUnique := filepath.Join(multiOutput, xid.NewWithTime(times[0]).String())
+		uniqueOutput := filepath.Join(multiUnique, "path1")
+		oldCustom := filepath.Join(customOutput, xid.NewWithTime(times[1]).String())
+		newCustom := filepath.Join(customOutput, xid.NewWithTime(times[2]).String())
+		extraFiles := [...]string{"orig", "bad", "good"}
+
+		for i, path := range [...]string{
+			uniqueOutput,
+			oldCustom,
+			newCustom,
+		} {
+			err := os.MkdirAll(path, internaldb.DirPerms)
+			So(err, ShouldBeNil)
+
+			err = createDirStructure(path, times[i], extraFiles[i])
+			So(err, ShouldBeNil)
+		}
+
+		err := Merge(customOutput, multiUnique, true)
+		So(err, ShouldBeNil)
+
+		err = checkFile(oldCustom)
+		So(err, ShouldNotBeNil)
+
+		err = checkFile(newCustom)
+		So(err, ShouldBeNil)
+
+		err = checkFile(filepath.Join(multiUnique, "bad"))
+		So(err, ShouldNotBeNil)
+
+		err = checkFile(filepath.Join(multiUnique, "good"))
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestCopy(t *testing.T) {
+	Convey("Given a directory tree", t, func() {
+		dir := t.TempDir()
+		newDir := t.TempDir()
+
+		err := createDirStructure(dir, time.Now().Add(time.Second*-10))
+		So(err, ShouldBeNil)
+
+		err = copyPreservingTimestamp(dir, newDir)
+		So(err, ShouldBeNil)
+
+		err = fs.WalkDir(os.DirFS(dir), ".", func(path string, de fs.DirEntry, errr error) error {
+			if errr != nil {
+				return errr
+			}
+
+			fs, errrr := de.Info()
+			So(errrr, ShouldBeNil)
+
+			mt := fs.ModTime()
+
+			fs, errrr = os.Lstat(filepath.Join(newDir, path))
+			So(errrr, ShouldBeNil)
+
+			So(fs.ModTime(), ShouldEqual, mt)
+
+			So(de.Type(), ShouldEqual, fs.Mode().Type())
+
+			return nil
+		})
+		So(err, ShouldBeNil)
+	})
+}
+
+func createDirStructure(base string, mt time.Time, extra ...string) error {
+	dirs := [...]string{".", "a", "b", "b/c", "b/d"}
+
+	for _, dir := range dirs[1:] {
+		p := filepath.Join(base, dir)
+
+		if err := os.Mkdir(p, 0755); err != nil {
+			return err
+		}
+	}
+
+	for _, file := range append(extra, "aFile", "a/notherFile", "b/d/e", "b/"+watchFile) {
+		p := filepath.Join(base, file)
+
+		err := neaten.CreateFile(p)
+		if err != nil {
+			return err
+		}
+
+		if err := ifs.Touch(p, mt); err != nil {
+			return err
+		}
+	}
+
+	slices.Reverse(dirs[:])
+
+	for _, dir := range dirs {
+		if err := ifs.Touch(filepath.Join(base, dir), mt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkFile(path string) error {
+	_, err := os.Lstat(path)
+
+	return err
+}

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -104,7 +104,7 @@ func createDirStructure(base string, mt time.Time, extra ...string) error {
 		}
 	}
 
-	for _, file := range append(extra, "aFile", "a/notherFile", "b/d/e", "b/d/"+watchFile) {
+	for _, file := range append(extra, "aFile", "a/notherFile", "b/d/e", "b/d/"+SentinelComplete) {
 		p := filepath.Join(base, file)
 
 		err := neaten.CreateFile(p)

--- a/neaten/copydb_test.go
+++ b/neaten/copydb_test.go
@@ -91,7 +91,7 @@ func makeFakeDgutDB(t *testing.T, dir string, subFolderNum int) {
 	}
 
 	for _, basename := range []string{"dgut.db", "dgut.db.children"} {
-		err = createFile(filepath.Join(subDir, basename))
+		err = CreateFile(filepath.Join(subDir, basename))
 		if err != nil {
 			t.Fatalf("failed to make subdir: %s", err)
 		}

--- a/neaten/neaten.go
+++ b/neaten/neaten.go
@@ -362,7 +362,7 @@ func (t *Tidy) touchDBUpdatedFile(dgutDBsSentinelBasename string) error {
 
 	_, err = os.Stat(sentinel)
 	if os.IsNotExist(err) {
-		if err = createFile(sentinel); err != nil {
+		if err = CreateFile(sentinel); err != nil {
 			return err
 		}
 	}
@@ -374,16 +374,14 @@ func (t *Tidy) touchDBUpdatedFile(dgutDBsSentinelBasename string) error {
 	return CorrectPerms(sentinel, t.destDirInfo)
 }
 
-// createFile creates a file in the given path.
-func createFile(path string) error {
+// CreateFile creates a file in the given path.
+func CreateFile(path string) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 
-	file.Close()
-
-	return nil
+	return file.Close()
 }
 
 // changeAMFileTime updates the a&m time of the given path to the given time.

--- a/neaten/neaten_test.go
+++ b/neaten/neaten_test.go
@@ -294,7 +294,7 @@ func createTestPath(dirs []string, basename ...string) string {
 	So(err, ShouldBeNil)
 
 	if len(basename) == 1 {
-		err = createFile(filepath.Join(wholeDir, basename[0]))
+		err = CreateFile(filepath.Join(wholeDir, basename[0]))
 		So(err, ShouldBeNil)
 	}
 
@@ -354,7 +354,7 @@ func TestTouch(t *testing.T) {
 		tdir := t.TempDir()
 		path := filepath.Join(tdir, "file")
 
-		err := createFile(path)
+		err := CreateFile(path)
 		So(err, ShouldBeNil)
 
 		before := time.Now().Add(-10 * time.Second)
@@ -381,7 +381,7 @@ func TestDeleteAllPrefixedFiles(t *testing.T) {
 		tdir := t.TempDir()
 		for _, name := range []string{"aaa", "aab", "baa"} {
 			path := filepath.Join(tdir, name)
-			err := createFile(path)
+			err := CreateFile(path)
 			So(err, ShouldBeNil)
 		}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -626,7 +626,7 @@ func TestServer(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						_, files := internaldata.FakeFilesForDGUTDBForBasedirsTesting(gid, uid)
-						tree, err = internaldb.CreateDGUTDBFromFakeFiles(t, files[:1])
+						tree, _, err = internaldb.CreateDGUTDBFromFakeFiles(t, files[:1])
 						So(err, ShouldBeNil)
 
 						pathNew, _, err := createExampleBasedirsDB(t, tree)
@@ -1579,7 +1579,7 @@ func createExampleBasedirsDB(t *testing.T, tree *dgut.Tree) (string, string, err
 		"/lustre/scratch125/",
 	})
 
-	err = bd.CreateDatabase(time.Now())
+	err = bd.CreateDatabase()
 	if err != nil {
 		return "", "", err
 	}

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -113,7 +113,7 @@ func UntilFileIsOld(path string, age time.Duration) error {
 			break
 		}
 
-		<-time.After(wait)
+		time.Sleep(wait)
 	}
 
 	return nil


### PR DESCRIPTION
There is a race condition between the current implementation of the merge subcommand and the server subcommand that causes results to be removed incorrectly.

Redesigned to pull in existing results (walk & stat) before being moved to the final output directory, so that the server doesn't have to care about preserving old results.