### PR TITLE
Use custom, lexically ordered, base64 encoding for all paths that will be read by WRStat

### DIFF
--- a/combine/dgut_test.go
+++ b/combine/dgut_test.go
@@ -36,6 +36,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/wtsi-ssg/wrstat/v5/dgut"
 	"github.com/wtsi-ssg/wrstat/v5/fs"
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 	"github.com/wtsi-ssg/wrstat/v5/summary"
 )
 
@@ -121,7 +122,7 @@ func buildDGUTContent(directory, gid, uid string, filetype, nestedFiles,
 	splitDir := recursivePath(directory)
 
 	for _, split := range splitDir {
-		DGUTContents += split + fmt.Sprintf("\t%s\t%s\t%d\t%d\t%d\t%d\t%d\n",
+		DGUTContents += encode.Base64Encode(split) + fmt.Sprintf("\t%s\t%s\t%d\t%d\t%d\t%d\t%d\n",
 			gid, uid, filetype, nestedFiles, fileSize, oldestAtime, newestAtime)
 	}
 

--- a/combine/stat_test.go
+++ b/combine/stat_test.go
@@ -27,7 +27,6 @@
 package combine
 
 import (
-	b64 "encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,6 +34,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/wtsi-ssg/wrstat/v5/fs"
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 )
 
 // TestStatFiles tests that the stat files concatenate and compress properly.
@@ -53,7 +53,7 @@ func TestStatFiles(t *testing.T) {
 				actualContent, err := fs.ReadCompressedFile(outputPath)
 				So(err, ShouldBeNil)
 
-				encodedDir := b64.StdEncoding.EncodeToString([]byte(dir))
+				encodedDir := encode.Base64Encode(dir)
 
 				expectedOutput := fmt.Sprintf(
 					"%s\t5\t345\t152\t217434\t82183\t147\t'f'\t3\t7\t28472\t\n"+
@@ -82,7 +82,7 @@ func buildStatFiles(t *testing.T) (string, []*os.File, *os.File, string) {
 
 		_, err = f.WriteString(fmt.Sprintf(
 			"%s\t%d\t%d\t%d\t%d\t%d\t%d\t%q\t%d\t%d\t%d\t\n",
-			b64.StdEncoding.EncodeToString([]byte(dir)),
+			encode.Base64Encode(dir),
 			5+i,
 			345,
 			152,

--- a/dgut/dgut_test.go
+++ b/dgut/dgut_test.go
@@ -34,41 +34,42 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/ugorji/go/codec"
 	internaldata "github.com/wtsi-ssg/wrstat/v5/internal/data"
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 	"github.com/wtsi-ssg/wrstat/v5/summary"
 	bolt "go.etcd.io/bbolt"
 )
 
 func TestDGUT(t *testing.T) {
 	Convey("You can parse a single line of dgut data", t, func() {
-		line := "/\t1\t101\t0\t3\t30\t50\t50\n"
+		line := encode.Base64Encode("/") + "\t1\t101\t0\t3\t30\t50\t50\n"
 		dir, gut, err := parseDGUTLine(line)
 		So(err, ShouldBeNil)
 		So(dir, ShouldEqual, "/")
 		So(gut, ShouldResemble, &GUT{GID: 1, UID: 101, FT: 0, Count: 3, Size: 30, Atime: 50, Mtime: 50})
 
 		Convey("But invalid data won't parse", func() {
-			_, _, err = parseDGUTLine("/\t1\t101\t0\t3\t50\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\t101\t0\t3\t50\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\tfoo\t101\t0\t3\t30\t50\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\tfoo\t101\t0\t3\t30\t50\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\t1\tfoo\t0\t3\t30\t50\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\tfoo\t0\t3\t30\t50\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\t1\t101\tfoo\t3\t30\t50\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\t101\tfoo\t3\t30\t50\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\t1\t101\t0\tfoo\t30\t50\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\t101\t0\tfoo\t30\t50\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\t1\t101\t0\t3\tfoo\t50\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\t101\t0\t3\tfoo\t50\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\t1\t101\t0\t3\t30\tfoo\t50\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\t101\t0\t3\t30\tfoo\t50\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
-			_, _, err = parseDGUTLine("/\t1\t101\t0\t3\t30\t50\tfoo\n")
+			_, _, err = parseDGUTLine(encode.Base64Encode("/") + "\t1\t101\t0\t3\t30\t50\tfoo\n")
 			So(err, ShouldEqual, ErrInvalidFormat)
 
 			So(err.Error(), ShouldEqual, "the provided data was not in dgut format")
@@ -379,9 +380,9 @@ func TestDGUT(t *testing.T) {
 					})
 
 					Convey("Store()ing multiple times", func() {
-						data = strings.NewReader("/\t3\t103\t7\t2\t2\t25\t25\n" +
-							"/a/i\t3\t103\t7\t1\t1\t25\t25\n" +
-							"/i\t3\t103\t7\t1\t1\t30\t30\n")
+						data = strings.NewReader(encode.Base64Encode("/") + "\t3\t103\t7\t2\t2\t25\t25\n" +
+							encode.Base64Encode("/a/i") + "\t3\t103\t7\t1\t1\t25\t25\n" +
+							encode.Base64Encode("/i") + "\t3\t103\t7\t1\t1\t30\t30\n")
 
 						Convey("to the same db file doesn't work", func() {
 							err = db.Store(data, 4)

--- a/dgut/parse.go
+++ b/dgut/parse.go
@@ -32,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 	"github.com/wtsi-ssg/wrstat/v5/summary"
 )
 
@@ -113,12 +114,17 @@ func parseDGUTLine(line string) (string, *GUT, error) {
 		return "", nil, ErrBlankLine
 	}
 
+	path, err := encode.Base64Decode(parts[0])
+	if err != nil {
+		return "", nil, err
+	}
+
 	ints, err := gutLinePartsToInts(parts)
 	if err != nil {
 		return "", nil, err
 	}
 
-	return parts[0], &GUT{
+	return path, &GUT{
 		GID:   uint32(ints[0]),
 		UID:   uint32(ints[1]),
 		FT:    summary.DirGUTFileType(ints[2]),

--- a/dgut/tree_test.go
+++ b/dgut/tree_test.go
@@ -32,6 +32,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	internaldata "github.com/wtsi-ssg/wrstat/v5/internal/data"
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 	"github.com/wtsi-ssg/wrstat/v5/internal/fs"
 	"github.com/wtsi-ssg/wrstat/v5/internal/split"
 	"github.com/wtsi-ssg/wrstat/v5/summary"
@@ -227,11 +228,11 @@ func TestTree(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		db := NewDB(paths1[0])
-		data := strings.NewReader("/\t1\t11\t6\t1\t1\t20\t20\n" +
-			"/a\t1\t11\t6\t1\t1\t20\t20\n" +
-			"/a/b\t1\t11\t6\t1\t1\t20\t20\n" +
-			"/a/b/c\t1\t11\t6\t1\t1\t20\t20\n" +
-			"/a/b/c/d\t1\t11\t6\t1\t1\t20\t20\n")
+		data := strings.NewReader(encode.Base64Encode("/") + "\t1\t11\t6\t1\t1\t20\t20\n" +
+			encode.Base64Encode("/a") + "\t1\t11\t6\t1\t1\t20\t20\n" +
+			encode.Base64Encode("/a/b") + "\t1\t11\t6\t1\t1\t20\t20\n" +
+			encode.Base64Encode("/a/b/c") + "\t1\t11\t6\t1\t1\t20\t20\n" +
+			encode.Base64Encode("/a/b/c/d") + "\t1\t11\t6\t1\t1\t20\t20\n")
 		err = db.Store(data, 20)
 		So(err, ShouldBeNil)
 
@@ -239,11 +240,11 @@ func TestTree(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		db = NewDB(paths2[0])
-		data = strings.NewReader("/\t1\t11\t6\t1\t1\t15\t15\n" +
-			"/a\t1\t11\t6\t1\t1\t15\t15\n" +
-			"/a/b\t1\t11\t6\t1\t1\t15\t15\n" +
-			"/a/b/c\t1\t11\t6\t1\t1\t15\t15\n" +
-			"/a/b/c/e\t1\t11\t6\t1\t1\t15\t15\n")
+		data = strings.NewReader(encode.Base64Encode("/") + "\t1\t11\t6\t1\t1\t15\t15\n" +
+			encode.Base64Encode("/a") + "\t1\t11\t6\t1\t1\t15\t15\n" +
+			encode.Base64Encode("/a/b") + "\t1\t11\t6\t1\t1\t15\t15\n" +
+			encode.Base64Encode("/a/b/c") + "\t1\t11\t6\t1\t1\t15\t15\n" +
+			encode.Base64Encode("/a/b/c/e") + "\t1\t11\t6\t1\t1\t15\t15\n")
 		err = db.Store(data, 20)
 		So(err, ShouldBeNil)
 

--- a/internal/encode/encode.go
+++ b/internal/encode/encode.go
@@ -27,9 +27,37 @@
 
 package encode
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"unsafe"
+)
 
-// Base64Encode encodes the given string in base64.
+var encoding = base64.NewEncoding("+/0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz") //nolint:gochecknoglobals,lll
+
+// Base64Encode encodes the given string to a lexically ordered base64.
 func Base64Encode(val string) string {
-	return base64.StdEncoding.EncodeToString([]byte(val))
+	if val == "" {
+		return ""
+	}
+
+	buf := make([]byte, encoding.EncodedLen(len(val)))
+
+	encoding.Encode(buf, unsafe.Slice(unsafe.StringData(val), len(val)))
+
+	return unsafe.String(&buf[0], len(buf))
+}
+
+// Base64Decode decodes the given encoded string from a lexically ordered Base64
+// encoding.
+func Base64Decode(val string) (string, error) {
+	if val == "" {
+		return "", nil
+	}
+
+	str, err := encoding.DecodeString(val)
+	if err != nil {
+		return "", err
+	}
+
+	return unsafe.String(&str[0], len(str)), nil
 }

--- a/internal/encode/encode_test.go
+++ b/internal/encode/encode_test.go
@@ -1,0 +1,17 @@
+package encode
+
+import "testing"
+
+func TestEncodeDecode(t *testing.T) {
+	for n, test := range [...]string{
+		"",
+		"abc",
+		"/some/path/",
+	} {
+		if output, err := Base64Decode(Base64Encode(test)); err != nil {
+			t.Errorf("test %d: unexpected error: %s", n+1, err)
+		} else if output != test {
+			t.Errorf("test %d: expected output %q, got %q", n+1, test, output)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1654,7 +1654,8 @@ yes y | WR_RunnerExecShell=sh wr manager start -s local --max_ram -1 --max_cores
 wrstat multi -m 0 -p -w /tmp/working/partial/ /simple/*;
 waitForJobs;
 
-wrstat multi -m 0 -w /tmp/working/complete/ -f /tmp/final/ -l /tmp/working/partial -q /tmp/quota -b /tmp/basedirs -o /tmp/owners /objects/*;
+wrstat multi -m 0 -w /tmp/working/complete/ -f /tmp/final/ -l `+
+			`/tmp/working/partial -q /tmp/quota -b /tmp/basedirs -o /tmp/owners /objects/*;
 waitForJobs;
 
 stop;`)
@@ -1921,7 +1922,8 @@ stop;`)
 				"\t512\t%[1]d\t%[2]d\t139\t139\t139\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/part1/other/my\nDir")+"\t0\t%[1]d\t%[2]d\t139\t139\t139\td\t\x00\t2\t32\n"+
 				encode.Base64Encode("/objects/store2/important")+"\t0\t0\t0\t146\t146\t146\td\t\x00\t3\t32\n"+
-				encode.Base64Encode("/objects/store2/important/docs\t/my.doc")+"\t512\t%[4]d\t%[3]d\t151\t151\t151\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/important/docs\t/my.doc")+
+				"\t512\t%[4]d\t%[3]d\t151\t151\t151\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/important/docs\t")+"\t0\t%[4]d\t%[3]d\t151\t151\t151\td\t\x00\t2\t32\n"+
 				encode.Base64Encode("/objects/store2/part0")+"\t0\t0\t0\t87\t87\t87\td\t\x00\t3\t32\n"+
 				encode.Base64Encode("/objects/store2/part0/teams")+"\t0\t0\t0\t109\t109\t109\td\t\x00\t4\t32\n"+

--- a/main_test.go
+++ b/main_test.go
@@ -959,8 +959,10 @@ func TestCombine(t *testing.T) {
 				encode.Base64Encode("/some/directory/001/aDirectory") + "\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
 				encode.Base64Encode("/some/directory/001/aDirectory") + "\t2000\t1000\t2\t3\t8202\t1721915848\t7383773\n" +
 				encode.Base64Encode("/some/directory/001/aDirectory") + "\t2000\t1000\t15\t2\t8192\t1721915848\t314159\n" +
-				encode.Base64Encode("/some/directory/001/aDirectory/aSubDirectory") + "\t2000\t1000\t2\t1\t4096\t1721915848\t314159\n" +
-				encode.Base64Encode("/some/directory/001/aDirectory/aSubDirectory") + "\t2000\t1000\t15\t1\t4096\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory/aSubDirectory") +
+				"\t2000\t1000\t2\t1\t4096\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory/aSubDirectory") +
+				"\t2000\t1000\t15\t1\t4096\t1721915848\t314159\n" +
 				encode.Base64Encode("/some/directory/001/anotherDirectory") + "\t2000\t1000\t2\t1\t4096\t1721915848\t282820\n" +
 				encode.Base64Encode("/some/directory/001/anotherDirectory") + "\t2000\t1000\t15\t1\t4096\t1721915848\t282820\n",
 			"a.log": "A log file\nwith 2 lines\n",
@@ -1916,17 +1918,20 @@ func TestEnd2End(t *testing.T) {
 				encode.Base64Encode("/objects/store2/part1")+"\t0\t0\t0\t123\t123\t123\td\t\x00\t3\t32\n"+
 				encode.Base64Encode("/objects/store2/part1/other/my.tmp.gz")+"\t512\t%[1]d\t%[3]d\t128\t128\t128\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/part1/other")+"\t0\t%[1]d\t%[2]d\t133\t133\t133\td\t\x00\t3\t32\n"+
-				encode.Base64Encode("/objects/store2/part1/other/myDir/my.tmp.old")+"\t512\t%[1]d\t%[2]d\t139\t139\t139\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part1/other/myDir/my.tmp.old")+
+				"\t512\t%[1]d\t%[2]d\t139\t139\t139\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/part1/other/myDir")+"\t0\t%[1]d\t%[2]d\t139\t139\t139\td\t\x00\t2\t32\n"+
 				encode.Base64Encode("/objects/store2/important")+"\t0\t0\t0\t146\t146\t146\td\t\x00\t3\t32\n"+
 				encode.Base64Encode("/objects/store2/important/docs/my.doc")+"\t512\t%[4]d\t%[3]d\t151\t151\t151\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/important/docs")+"\t0\t%[4]d\t%[3]d\t151\t151\t151\td\t\x00\t2\t32\n"+
 				encode.Base64Encode("/objects/store2/part0")+"\t0\t0\t0\t87\t87\t87\td\t\x00\t3\t32\n"+
 				encode.Base64Encode("/objects/store2/part0/teams")+"\t0\t0\t0\t109\t109\t109\td\t\x00\t4\t32\n"+
-				encode.Base64Encode("/objects/store2/part0/teams/team2/c.txt")+"\t512\t%[4]d\t%[5]d\t115\t115\t115\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team2/c.txt")+
+				"\t512\t%[4]d\t%[5]d\t115\t115\t115\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/part0/teams/team2")+"\t0\t%[4]d\t%[5]d\t115\t115\t115\td\t\x00\t2\t32\n"+
 				encode.Base64Encode("/objects/store2/part0/teams/team1/a.txt")+"\t100\t%[6]d\t%[2]d\t98\t98\t98\tf\t\x00\t1\t34\n"+
-				encode.Base64Encode("/objects/store2/part0/teams/team1/b.txt")+"\t200\t%[6]d\t%[5]d\t104\t104\t104\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team1/b.txt")+
+				"\t200\t%[6]d\t%[5]d\t104\t104\t104\tf\t\x00\t1\t34\n"+
 				encode.Base64Encode("/objects/store2/part0/teams/team1")+"\t0\t%[6]d\t%[2]d\t104\t104\t104\td\t\x00\t2\t32",
 				UserD, GroupA, GroupD, UserB, GroupB, UserA),
 			"????????_store3.*.stats.gz": fmt.Sprintf(""+

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,6 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -613,10 +612,11 @@ func TestWalk(t *testing.T) {
 
 		jobsExpectation := []*jobqueue.Job{
 			{
-				Cmd:        exe + " stat " + walk1,
-				CwdMatters: true,
-				RepGroup:   "wrstat-stat-" + filepath.Base(tmp) + "-" + time.Now().Format("20060102"),
-				ReqGroup:   "wrstat-stat",
+				Cmd:         exe + " stat " + walk1,
+				CwdMatters:  true,
+				LimitGroups: []string{"wrstat-stat"},
+				RepGroup:    "wrstat-stat-" + filepath.Base(tmp) + "-" + time.Now().Format("20060102"),
+				ReqGroup:    "wrstat-stat",
 				Requirements: &scheduler.Requirements{
 					RAM:   750,
 					Time:  12 * time.Hour,
@@ -650,10 +650,11 @@ func TestWalk(t *testing.T) {
 
 		jobsExpectation = []*jobqueue.Job{
 			{
-				Cmd:        exe + " stat " + walk1,
-				CwdMatters: true,
-				RepGroup:   "wrstat-stat-" + filepath.Base(tmp) + "-" + time.Now().Format("20060102"),
-				ReqGroup:   "wrstat-stat",
+				Cmd:         exe + " stat " + walk1,
+				CwdMatters:  true,
+				LimitGroups: []string{"wrstat-stat"},
+				RepGroup:    "wrstat-stat-" + filepath.Base(tmp) + "-" + time.Now().Format("20060102"),
+				ReqGroup:    "wrstat-stat",
 				Requirements: &scheduler.Requirements{
 					RAM:   750,
 					Time:  12 * time.Hour,
@@ -665,10 +666,11 @@ func TestWalk(t *testing.T) {
 				DepGroups: []string{depgroup},
 			},
 			{
-				Cmd:        exe + " stat " + walk2,
-				CwdMatters: true,
-				RepGroup:   "wrstat-stat-" + filepath.Base(tmp) + "-" + time.Now().Format("20060102"),
-				ReqGroup:   "wrstat-stat",
+				Cmd:         exe + " stat " + walk2,
+				CwdMatters:  true,
+				LimitGroups: []string{"wrstat-stat"},
+				RepGroup:    "wrstat-stat-" + filepath.Base(tmp) + "-" + time.Now().Format("20060102"),
+				ReqGroup:    "wrstat-stat",
 				Requirements: &scheduler.Requirements{
 					RAM:   750,
 					Time:  12 * time.Hour,
@@ -846,11 +848,11 @@ func TestStat(t *testing.T) {
 			"%[7]s\t4096\t%[1]s\t%[2]s\t%[18]d\t282820\t%[23]d\td\t%[12]d\t2\t%[13]d\n",
 			u.Uid,
 			u.Gid,
-			base64.StdEncoding.EncodeToString([]byte(tmp)),
-			base64.StdEncoding.EncodeToString([]byte(filepath.Join(tmp, "aDirectory"))),
-			base64.StdEncoding.EncodeToString([]byte(filepath.Join(tmp, "aDirectory", "aFile\nfile"))),
-			base64.StdEncoding.EncodeToString([]byte(filepath.Join(tmp, "aDirectory", "aSubDirectory"))),
-			base64.StdEncoding.EncodeToString([]byte(filepath.Join(tmp, "anotherDirectory"))),
+			encode.Base64Encode(tmp),
+			encode.Base64Encode(filepath.Join(tmp, "aDirectory")),
+			encode.Base64Encode(filepath.Join(tmp, "aDirectory", "aFile\nfile")),
+			encode.Base64Encode(filepath.Join(tmp, "aDirectory", "aSubDirectory")),
+			encode.Base64Encode(filepath.Join(tmp, "anotherDirectory")),
 			inodes[4],
 			inodes[2],
 			inodes[0],
@@ -942,25 +944,25 @@ func TestCombine(t *testing.T) {
 			"b.bygroup":     "e\tf\tg\th\n5\t6\t7\t8\n",
 			"c.bygroup":     "",
 			"a.dgut": "" +
-				"/\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
-				"/\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
-				"/\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
-				"/some\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
-				"/some\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
-				"/some\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
-				"/some/directory\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
-				"/some/directory\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
-				"/some/directory\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
-				"/some/directory/001\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
-				"/some/directory/001\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
-				"/some/directory/001\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
-				"/some/directory/001/aDirectory\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
-				"/some/directory/001/aDirectory\t2000\t1000\t2\t3\t8202\t1721915848\t7383773\n" +
-				"/some/directory/001/aDirectory\t2000\t1000\t15\t2\t8192\t1721915848\t314159\n" +
-				"/some/directory/001/aDirectory/aSubDirectory\t2000\t1000\t2\t1\t4096\t1721915848\t314159\n" +
-				"/some/directory/001/aDirectory/aSubDirectory\t2000\t1000\t15\t1\t4096\t1721915848\t314159\n" +
-				"/some/directory/001/anotherDirectory\t2000\t1000\t2\t1\t4096\t1721915848\t282820\n" +
-				"/some/directory/001/anotherDirectory\t2000\t1000\t15\t1\t4096\t1721915848\t282820\n",
+				encode.Base64Encode("/") + "\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
+				encode.Base64Encode("/") + "\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
+				encode.Base64Encode("/") + "\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
+				encode.Base64Encode("/some") + "\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some") + "\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some") + "\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory") + "\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some/directory") + "\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some/directory") + "\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001") + "\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some/directory/001") + "\t2000\t1000\t2\t5\t16394\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some/directory/001") + "\t2000\t1000\t15\t4\t16384\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory") + "\t2000\t1000\t0\t1\t10\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory") + "\t2000\t1000\t2\t3\t8202\t1721915848\t7383773\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory") + "\t2000\t1000\t15\t2\t8192\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory/aSubDirectory") + "\t2000\t1000\t2\t1\t4096\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001/aDirectory/aSubDirectory") + "\t2000\t1000\t15\t1\t4096\t1721915848\t314159\n" +
+				encode.Base64Encode("/some/directory/001/anotherDirectory") + "\t2000\t1000\t2\t1\t4096\t1721915848\t282820\n" +
+				encode.Base64Encode("/some/directory/001/anotherDirectory") + "\t2000\t1000\t15\t1\t4096\t1721915848\t282820\n",
 			"a.log": "A log file\nwith 2 lines\n",
 			"b.log": "Another log file, with 1 line\n",
 			"c.log": "Lorem ipsum!!!!",
@@ -1884,52 +1886,52 @@ func TestEnd2End(t *testing.T) {
 			"????????_store2.*.logs.gz": "",
 			"????????_store3.*.logs.gz": "",
 			"????????_A.*.stats.gz": fmt.Sprintf(""+
-				"L3NpbXBsZS9BL2EuZmlsZQ==\t1\t%[1]d\t%[2]d\t160\t160\t160\tf\t\x00\t1\t34\n"+
-				"L3NpbXBsZS9B\t0\t%[1]d\t%[2]d\t160\t160\t160\td\t\x00\t2\t32",
+				encode.Base64Encode("/simple/A/a.file")+"\t1\t%[1]d\t%[2]d\t160\t160\t160\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/simple/A")+"\t0\t%[1]d\t%[2]d\t160\t160\t160\td\t\x00\t2\t32",
 				UserA, GroupA),
 			"????????_E.*.stats.gz": fmt.Sprintf(""+
-				"L3NpbXBsZS9FL2IudG1w\t2\t%[1]d\t%[2]d\t165\t165\t165\tf\t\x00\t1\t34\n"+
-				"L3NpbXBsZS9F\t0\t%[1]d\t%[2]d\t165\t165\t165\td\t\x00\t2\t32",
+				encode.Base64Encode("/simple/E/b.tmp")+"\t2\t%[1]d\t%[2]d\t165\t165\t165\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/simple/E")+"\t0\t%[1]d\t%[2]d\t165\t165\t165\td\t\x00\t2\t32",
 				UserE, GroupE),
 			"????????_store1.*.stats.gz": fmt.Sprintf(""+
-				"L29iamVjdHMvc3RvcmUx\t0\t0\t0\t10\t10\t10\td\t\x00\t3\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGE=\t0\t0\t0\t42\t42\t42\td\t\x00\t5\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcA==\t0\t%[1]d\t%[2]d\t69\t69\t69\td\t\x00\t5\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcC9jL2MuYmVk\t512\t%[1]d\t%[2]d\t75\t75\t75\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcC9j\t0\t%[1]d\t%[2]d\t75\t75\t75\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvZGJzL2RiQS5kYg==\t512\t%[3]d\t%[2]d\t33\t33\t33\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvZGJzL2RiQi5kYg==\t512\t%[3]d\t%[2]d\t38\t38\t38\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvZGJz\t0\t%[3]d\t%[2]d\t38\t38\t38\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvc2hlZXRzL2RvYzEudHh0\t512\t%[4]d\t%[2]d\t19\t19\t19\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvc2hlZXRzL2RvYzIudHh0\t512\t%[4]d\t%[2]d\t24\t24\t24\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvc2hlZXRz\t0\t%[4]d\t%[2]d\t24\t24\t24\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcC9hL2EuYmVk\t512\t%[1]d\t%[2]d\t53\t53\t53\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcC9h\t0\t%[1]d\t%[2]d\t53\t53\t53\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcC9iL2IuYmVk\t512\t%[1]d\t%[2]d\t64\t64\t64\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUxL2RhdGEvdGVtcC9i\t0\t%[1]d\t%[2]d\t64\t64\t64\td\t\x00\t2\t32",
+				encode.Base64Encode("/objects/store1")+"\t0\t0\t0\t10\t10\t10\td\t\x00\t3\t32\n"+
+				encode.Base64Encode("/objects/store1/data")+"\t0\t0\t0\t42\t42\t42\td\t\x00\t5\t32\n"+
+				encode.Base64Encode("/objects/store1/data/temp")+"\t0\t%[1]d\t%[2]d\t69\t69\t69\td\t\x00\t5\t32\n"+
+				encode.Base64Encode("/objects/store1/data/temp/c/c.bed")+"\t512\t%[1]d\t%[2]d\t75\t75\t75\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/temp/c")+"\t0\t%[1]d\t%[2]d\t75\t75\t75\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store1/data/dbs/dbA.db")+"\t512\t%[3]d\t%[2]d\t33\t33\t33\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/dbs/dbB.db")+"\t512\t%[3]d\t%[2]d\t38\t38\t38\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/dbs")+"\t0\t%[3]d\t%[2]d\t38\t38\t38\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store1/data/sheets/doc1.txt")+"\t512\t%[4]d\t%[2]d\t19\t19\t19\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/sheets/doc2.txt")+"\t512\t%[4]d\t%[2]d\t24\t24\t24\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/sheets")+"\t0\t%[4]d\t%[2]d\t24\t24\t24\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store1/data/temp/a/a.bed")+"\t512\t%[1]d\t%[2]d\t53\t53\t53\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/temp/a")+"\t0\t%[1]d\t%[2]d\t53\t53\t53\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store1/data/temp/b/b.bed")+"\t512\t%[1]d\t%[2]d\t64\t64\t64\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store1/data/temp/b")+"\t0\t%[1]d\t%[2]d\t64\t64\t64\td\t\x00\t2\t32",
 				UserC, GroupA, UserB, UserA),
 			"????????_store2.*.stats.gz": fmt.Sprintf(""+
-				"L29iamVjdHMvc3RvcmUy\t0\t0\t0\t142\t142\t142\td\t\x00\t5\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQxL290aGVyLmJlZA==\t512\t%[1]d\t%[2]d\t119\t119\t119\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQx\t0\t0\t0\t123\t123\t123\td\t\x00\t3\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQxL290aGVyL215LnRtcC5neg==\t512\t%[1]d\t%[3]d\t128\t128\t128\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQxL290aGVy\t0\t%[1]d\t%[2]d\t133\t133\t133\td\t\x00\t3\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQxL290aGVyL215RGlyL215LnRtcC5vbGQ=\t512\t%[1]d\t%[2]d\t139\t139\t139\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQxL290aGVyL215RGly\t0\t%[1]d\t%[2]d\t139\t139\t139\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL2ltcG9ydGFudA==\t0\t0\t0\t146\t146\t146\td\t\x00\t3\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL2ltcG9ydGFudC9kb2NzL215LmRvYw==\t512\t%[4]d\t%[3]d\t151\t151\t151\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL2ltcG9ydGFudC9kb2Nz\t0\t%[4]d\t%[3]d\t151\t151\t151\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQw\t0\t0\t0\t87\t87\t87\td\t\x00\t3\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQwL3RlYW1z\t0\t0\t0\t109\t109\t109\td\t\x00\t4\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQwL3RlYW1zL3RlYW0yL2MudHh0\t512\t%[4]d\t%[5]d\t115\t115\t115\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQwL3RlYW1zL3RlYW0y\t0\t%[4]d\t%[5]d\t115\t115\t115\td\t\x00\t2\t32\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQwL3RlYW1zL3RlYW0xL2EudHh0\t100\t%[6]d\t%[2]d\t98\t98\t98\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQwL3RlYW1zL3RlYW0xL2IudHh0\t200\t%[6]d\t%[5]d\t104\t104\t104\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUyL3BhcnQwL3RlYW1zL3RlYW0x\t0\t%[6]d\t%[2]d\t104\t104\t104\td\t\x00\t2\t32",
+				encode.Base64Encode("/objects/store2")+"\t0\t0\t0\t142\t142\t142\td\t\x00\t5\t32\n"+
+				encode.Base64Encode("/objects/store2/part1/other.bed")+"\t512\t%[1]d\t%[2]d\t119\t119\t119\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part1")+"\t0\t0\t0\t123\t123\t123\td\t\x00\t3\t32\n"+
+				encode.Base64Encode("/objects/store2/part1/other/my.tmp.gz")+"\t512\t%[1]d\t%[3]d\t128\t128\t128\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part1/other")+"\t0\t%[1]d\t%[2]d\t133\t133\t133\td\t\x00\t3\t32\n"+
+				encode.Base64Encode("/objects/store2/part1/other/myDir/my.tmp.old")+"\t512\t%[1]d\t%[2]d\t139\t139\t139\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part1/other/myDir")+"\t0\t%[1]d\t%[2]d\t139\t139\t139\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store2/important")+"\t0\t0\t0\t146\t146\t146\td\t\x00\t3\t32\n"+
+				encode.Base64Encode("/objects/store2/important/docs/my.doc")+"\t512\t%[4]d\t%[3]d\t151\t151\t151\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/important/docs")+"\t0\t%[4]d\t%[3]d\t151\t151\t151\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store2/part0")+"\t0\t0\t0\t87\t87\t87\td\t\x00\t3\t32\n"+
+				encode.Base64Encode("/objects/store2/part0/teams")+"\t0\t0\t0\t109\t109\t109\td\t\x00\t4\t32\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team2/c.txt")+"\t512\t%[4]d\t%[5]d\t115\t115\t115\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team2")+"\t0\t%[4]d\t%[5]d\t115\t115\t115\td\t\x00\t2\t32\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team1/a.txt")+"\t100\t%[6]d\t%[2]d\t98\t98\t98\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team1/b.txt")+"\t200\t%[6]d\t%[5]d\t104\t104\t104\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store2/part0/teams/team1")+"\t0\t%[6]d\t%[2]d\t104\t104\t104\td\t\x00\t2\t32",
 				UserD, GroupA, GroupD, UserB, GroupB, UserA),
 			"????????_store3.*.stats.gz": fmt.Sprintf(""+
-				"L29iamVjdHMvc3RvcmUzL2FGaWxl\t512\t%d\t%d\t154\t154\t154\tf\t\x00\t1\t34\n"+
-				"L29iamVjdHMvc3RvcmUz\t0\t0\t0\t154\t154\t154\td\t\x00\t2\t32",
+				encode.Base64Encode("/objects/store3/aFile")+"\t512\t%d\t%d\t154\t154\t154\tf\t\x00\t1\t34\n"+
+				encode.Base64Encode("/objects/store3")+"\t0\t0\t0\t154\t154\t154\td\t\x00\t2\t32",
 				UserA, GroupA),
 		} {
 			files, errr := fs.Glob(os.DirFS(tmpTemp), filepath.Join("final", file))

--- a/stat/file_test.go
+++ b/stat/file_test.go
@@ -71,8 +71,8 @@ func TestStatFile(t *testing.T) {
 	})
 
 	Convey("base64Encode() works correctly", t, func() {
-		So(encode.Base64Encode("/a/path/reg"), ShouldEqual, "L2EvcGF0aC9yZWc=")
-		So(encode.Base64Encode("/a/path/link"), ShouldEqual, "L2EvcGF0aC9saW5r")
+		So(encode.Base64Encode("/a/path/reg"), ShouldEqual, "9q2jQ43oO0xmNKQ=")
+		So(encode.Base64Encode("/a/path/link"), ShouldEqual, "9q2jQ43oO0xgOKtf")
 	})
 
 	Convey("File() returns the correct interpretation of FileInfo", t, func() {
@@ -128,7 +128,7 @@ func testFileStats(path string, size int64, filetype string) {
 
 	So(stats.ToString(), ShouldEqual, fmt.Sprintf(
 		"%s\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\n",
-		"L2Ficy9wYXRoL3RvL2ZpbGU=", size, stat.Uid, stat.Gid,
+		encode.Base64Encode("/abs/path/to/file"), size, stat.Uid, stat.Gid,
 		stat.Atim.Sec, stat.Mtim.Sec, stat.Ctim.Sec,
 		filetype, stat.Ino, stat.Nlink, stat.Dev))
 }

--- a/stat/paths.go
+++ b/stat/paths.go
@@ -27,13 +27,13 @@ package stat
 
 import (
 	"bufio"
-	"encoding/base64"
 	"io"
 	"io/fs"
 	"sync"
 	"time"
 
 	"github.com/inconshreveable/log15"
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 	"github.com/wtsi-ssg/wrstat/v5/reporter"
 )
 
@@ -105,7 +105,7 @@ func (p *Paths) Scan(paths io.Reader) error {
 	var wg sync.WaitGroup
 
 	for scanner.Scan() {
-		path, err := base64Decode(scanner.Text())
+		path, err := encode.Base64Decode(scanner.Text())
 		if err != nil {
 			return err
 		}
@@ -125,12 +125,6 @@ func (p *Paths) Scan(paths io.Reader) error {
 	p.stopReporting()
 
 	return scanner.Err()
-}
-
-func base64Decode(val string) (string, error) {
-	data, err := base64.StdEncoding.DecodeString(val)
-
-	return string(data), err
 }
 
 // startReporting calls StartReproting on all our reporters.

--- a/summary/dirgut.go
+++ b/summary/dirgut.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 )
 
 // DirGUTFileType is one of the special file types that the
@@ -473,7 +475,11 @@ func (d *DirGroupUserType) Output(output StringCloser) error {
 
 		for j, dgut := range dguts {
 			s := summaries[j]
-			_, errw := output.WriteString(fmt.Sprintf("%s\t%s\t%d\t%d\t%d\t%d\n", dir, dgut, s.count, s.size, s.atime, s.mtime))
+			_, errw := output.WriteString(fmt.Sprintf("%s\t%s\t%d\t%d\t%d\t%d\n",
+				encode.Base64Encode(dir),
+				dgut,
+				s.count, s.size,
+				s.atime, s.mtime))
 
 			if errw != nil {
 				return errw

--- a/summary/dirgut_test.go
+++ b/summary/dirgut_test.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/wtsi-ssg/wrstat/v5/internal/encode"
 )
 
 func TestDirGUTFileType(t *testing.T) {
@@ -389,12 +390,12 @@ func TestDirGUT(t *testing.T) {
 					So(errr, ShouldBeNil)
 					output := string(o)
 
-					So(output, ShouldContainSubstring, "/a/b/c/d\t2\t10\t7\t1\t2\t200\t200\n")
-					So(output, ShouldContainSubstring, "/a/b/c\t"+cuidKey+"\t2\t30\t0\t0\n")
-					So(output, ShouldContainSubstring, "/a/b\t"+cuidKey+"\t3\t60\t0\t0\n")
-					So(output, ShouldContainSubstring, "/a/b\t2\t2\t13\t1\t5\t0\t0\n")
-					So(output, ShouldContainSubstring, "/a/b\t2\t2\t6\t1\t3\t100\t0\n")
-					So(output, ShouldContainSubstring, "/\t3\t2\t13\t1\t6\t0\t0\n")
+					So(output, ShouldContainSubstring, encode.Base64Encode("/a/b/c/d")+"\t2\t10\t7\t1\t2\t200\t200\n")
+					So(output, ShouldContainSubstring, encode.Base64Encode("/a/b/c")+"\t"+cuidKey+"\t2\t30\t0\t0\n")
+					So(output, ShouldContainSubstring, encode.Base64Encode("/a/b")+"\t"+cuidKey+"\t3\t60\t0\t0\n")
+					So(output, ShouldContainSubstring, encode.Base64Encode("/a/b")+"\t2\t2\t13\t1\t5\t0\t0\n")
+					So(output, ShouldContainSubstring, encode.Base64Encode("/a/b")+"\t2\t2\t6\t1\t3\t100\t0\n")
+					So(output, ShouldContainSubstring, encode.Base64Encode("/")+"\t3\t2\t13\t1\t6\t0\t0\n")
 
 					So(checkFileIsSorted(outPath), ShouldBeTrue)
 				})


### PR DESCRIPTION
Modified internal encoding package to use a modified base64 encoding that produces encodings that preserves lexical ordering of paths.

Fixes issue during combine step where the newline and/or tab characters in a path would alter the number of columns in a TSV, which caused an index-out-of-range error as columns numbers didn't match when comparing rows in dgut files.