### PR TITLE
Fix for negative timestamps in summaries.

### DIFF
--- a/summary/summary.go
+++ b/summary/summary.go
@@ -54,11 +54,11 @@ type summaryWithAtime struct {
 func (s *summaryWithAtime) add(size int64, atime int64, mtime int64) {
 	s.summary.add(size)
 
-	if s.atime == 0 || atime < s.atime {
+	if atime > 0 && (s.atime == 0 || atime < s.atime) {
 		s.atime = atime
 	}
 
-	if s.mtime == 0 || mtime > s.mtime {
+	if mtime > 0 && (s.mtime == 0 || mtime > s.mtime) {
 		s.mtime = mtime
 	}
 }

--- a/summary/summary_test.go
+++ b/summary/summary_test.go
@@ -45,4 +45,28 @@ func TestSummary(t *testing.T) {
 			So(s.size, ShouldEqual, 30)
 		})
 	})
+
+	Convey("Given a summaryWithAtime", t, func() {
+		s := &summaryWithAtime{}
+
+		Convey("You can add sizes and atime/mtimes to it", func() {
+			s.add(10, 12, 24)
+			So(s.count, ShouldEqual, 1)
+			So(s.size, ShouldEqual, 10)
+			So(s.atime, ShouldEqual, 12)
+			So(s.mtime, ShouldEqual, 24)
+
+			s.add(20, -5, -10)
+			So(s.count, ShouldEqual, 2)
+			So(s.size, ShouldEqual, 30)
+			So(s.atime, ShouldEqual, 12)
+			So(s.mtime, ShouldEqual, 24)
+
+			s.add(30, 1, 30)
+			So(s.count, ShouldEqual, 3)
+			So(s.size, ShouldEqual, 60)
+			So(s.atime, ShouldEqual, 1)
+			So(s.mtime, ShouldEqual, 30)
+		})
+	})
 }


### PR DESCRIPTION
Certain files were able to produce a negative timestamp (-1) in DGUT summaries which the DGUT parser didn't like.