### PR TITLE
Asynchronously write to walk output files

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,5 +22,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.59.1
+          version: v1.62.0
           only-new-issues: true

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -274,12 +274,10 @@ func walkDirectory(ctx context.Context, dirent Dirent,
 	childControllers := make([]*flowController, len(children))
 
 	for n, child := range children {
-		childControllers[n] = newController()
-
 		if child.IsDir() {
+			childControllers[n] = newController()
+
 			go walkDirectory(ctx, child, childControllers[n], request, sendDirs)
-		} else {
-			go sendFileEntry(ctx, child, childControllers[n])
 		}
 	}
 
@@ -289,17 +287,14 @@ func walkDirectory(ctx context.Context, dirent Dirent,
 		sendEntry(ctx, dirent, control)
 	}
 
-	for _, childController := range childControllers {
-		childController.PassControl(control)
+	for n, childController := range childControllers {
+		if childController == nil {
+			sendEntry(ctx, children[n], control)
+		} else {
+			childController.PassControl(control)
+		}
 	}
 
-	flowControl.EndControl()
-}
-
-func sendFileEntry(ctx context.Context, dirent Dirent, flowControl *flowController) {
-	control := flowControl.GetControl()
-
-	sendEntry(ctx, dirent, control)
 	flowControl.EndControl()
 }
 


### PR DESCRIPTION
Attempt to reduce how far behind the writing is to the walk itself. Should reduce memory usage, if not total runtime.

Also reduce number of goroutines to reduce memory usage.