### PR TITLE
Fix hex decoding bug

### DIFF
--- a/combine/merge.go
+++ b/combine/merge.go
@@ -142,7 +142,7 @@ func (u *unquoter) readHex(n int) rune { //nolint:gocyclo
 	var r rune
 
 	for range n {
-		r <<= 8
+		r <<= 4
 
 		x := u.next()
 		if '0' <= x && x <= '9' { //nolint:gocritic,nestif

--- a/combine/merge_test.go
+++ b/combine/merge_test.go
@@ -76,6 +76,15 @@ func TestMergeSortedFiles(t *testing.T) {
 					"\"/a/b/c/dz\"\t3\t2\t1\t3\n\"/a/b/cz/\"\t0\t10\t2\t3\n",
 				UnquoteComparison: true,
 			},
+			{
+				Inputs: []string{
+					"\"/a/b/c/d\"\t3\t2\t1\t3\n\"/a/b/c/\\x1b[0m\\x1b[01\"\t0\t10\t2\t3",
+					"\"/a/b/c/dz\"\t3\t2\t1\t3\n\"/a/b/cz/\"\t0\t10\t2\t3",
+				},
+				Output: "\"/a/b/c/d\"\t3\t2\t1\t3\n\"/a/b/c/\\x1b[0m\\x1b[01\"\t0\t10\t2\t3\n" +
+					"\"/a/b/c/dz\"\t3\t2\t1\t3\n\"/a/b/cz/\"\t0\t10\t2\t3\n",
+				UnquoteComparison: true,
+			},
 		} {
 			files := make([]*os.File, len(test.Inputs))
 


### PR DESCRIPTION
The merge sort is currently incorrectly sorting escaped hex chars due to a typo.