### PR TITLE
Correct decoding of hex-encoded unicode chars

### DIFF
--- a/combine/merge.go
+++ b/combine/merge.go
@@ -111,7 +111,7 @@ func unquote(str []byte) ([]byte, error) { //nolint:gocognit,gocyclo,cyclop,funl
 			case '0', '1', '2', '3', '4', '5', '6', '7':
 				dst, str, err = appendOctal(dst, str, d)
 			case 'x':
-				dst, str, err = appendHex(dst, str)
+				dst, str, err = appendHexes(dst, str, 1)
 			case 'u':
 				dst, str, err = appendHexes(dst, str, 2) //nolint:mnd
 			case 'U':
@@ -156,23 +156,21 @@ func appendHex(dst, str []byte) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	if v := a<<4 | b; v != 0 { //nolint:mnd
-		dst = append(dst, v)
-	}
-
-	return dst, str[2:], nil
+	return append(dst, a<<4|b), str[2:], nil
 }
 
 func appendHexes(dst, str []byte, n int) ([]byte, []byte, error) {
-	var err error
+	orig := dst
 
 	for range n {
+		var err error
+
 		if dst, str, err = appendHex(dst, str); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	return dst, str, nil
+	return append(orig, bytes.TrimLeft(dst[len(orig):], "\x00")...), str, nil
 }
 
 func readHexNibble(x byte) (byte, error) {

--- a/combine/merge.go
+++ b/combine/merge.go
@@ -156,7 +156,11 @@ func appendHex(dst, str []byte) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	return append(dst, a<<4|b), str[2:], nil
+	if v := a<<4 | b; v != 0 { //nolint:mnd
+		dst = append(dst, v)
+	}
+
+	return dst, str[2:], nil
 }
 
 func appendHexes(dst, str []byte, n int) ([]byte, []byte, error) {

--- a/combine/merge_test.go
+++ b/combine/merge_test.go
@@ -85,6 +85,15 @@ func TestMergeSortedFiles(t *testing.T) {
 					"\"/a/b/c/dz\"\t3\t2\t1\t3\n\"/a/b/cz/\"\t0\t10\t2\t3\n",
 				UnquoteComparison: true,
 			},
+			{
+				Inputs: []string{
+					"\"/a/b/c/d\"\t3\t2\t1\t3\n\"/a/b/c/\\u00a0\"\t0\t10\t2\t3",
+					"\"/a/b/c/dz\"\t3\t2\t1\t3\n\"/a/b/cz/\"\t0\t10\t2\t3",
+				},
+				Output: "\"/a/b/c/d\"\t3\t2\t1\t3\n\"/a/b/c/dz\"\t3\t2\t1\t3\n" +
+					"\"/a/b/c/\\u00a0\"\t0\t10\t2\t3\n\"/a/b/cz/\"\t0\t10\t2\t3\n",
+				UnquoteComparison: true,
+			},
 		} {
 			files := make([]*os.File, len(test.Inputs))
 


### PR DESCRIPTION
Fixes merging issue where unicode chars between 0x80 and 0x100 (0xA0, in this case) where being incorrectly decoded.